### PR TITLE
Adding strategy and setting it to recreate

### DIFF
--- a/charts/vm-import-controller/templates/deployment.yaml
+++ b/charts/vm-import-controller/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "vm-import-controller.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "vm-import-controller.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
**Problem:**
https://github.com/harvester/vm-import-controller/issues/23
TLDR; Upgrade gets stuck due to RWO volume and strategy is set to the default rolling.

**Solution:**
Add
```
spec:strategy:type=Recreate
```

This will cause it to delete the old pod then spin up it's replacement.

**Related Issue:**

**Test plan:**
https://drone-publish.rancher.io/harvester/vm-import-controller/97