### PR TITLE
logs: Log errors when client fails verification

### DIFF
--- a/pkg/controllers/migration/openstack.go
+++ b/pkg/controllers/migration/openstack.go
@@ -53,6 +53,13 @@ func (h *openstackHandler) OnSourceChange(key string, o *migration.OpenstackSour
 
 		err = client.Verify()
 		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"apiVersion": o.APIVersion,
+				"kind":       o.Kind,
+				"name":       o.Name,
+				"namespace":  o.Namespace,
+				"err":        err,
+			}).Error("failed to verfiy client for openstack migration")
 			conds := []common.Condition{
 				{
 					Type:               migration.ClusterErrorCondition,

--- a/pkg/controllers/migration/vmware.go
+++ b/pkg/controllers/migration/vmware.go
@@ -51,6 +51,13 @@ func (h *vmwareHandler) OnSourceChange(key string, v *migration.VmwareSource) (*
 
 		err = client.Verify()
 		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"apiVersion": v.APIVersion,
+				"kind":       v.Kind,
+				"name":       v.Name,
+				"namespace":  v.Namespace,
+				"err":        err,
+			}).Error("failed to verfiy client for vmware migration")
 			// unable to find specific datacenter
 			conds := []common.Condition{
 				{


### PR DESCRIPTION
Log errors in the OpenStack and VMWare import controllers when the client fails to verify.

The client for VMWare and OpenStack VM import are constructed and then verified in an additional step. Instead of just indicating that there was an error with the status conditions, this change adds a log message to the controllers logs, which gives an indication why the verification failed.

related-to: https://github.com/harvester/vm-import-controller/issues/26

**Test plan:**

1. Setup Harvester and OpenStack or VMWare
2. Cause the verify step to fail (e.g. by blocking port 13774 for OpenStack)
3. A log message with a detailed error should appear when the status conditions on the migration resource are set to indicate an error
