### PR TITLE
enable smm when secureboot is enabled for openstack sources

### DIFF
--- a/pkg/source/openstack/client.go
+++ b/pkg/source/openstack/client.go
@@ -382,6 +382,11 @@ func (c *Client) GenerateVirtualMachine(vm *migration.VirtualMachineImport) (*ku
 							corev1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", flavorObj.VCPUs)),
 						},
 					},
+					Features: &kubevirt.Features{
+						ACPI: kubevirt.FeatureState{
+							Enabled: &boolTrue,
+						},
+					},
 				},
 			},
 		},
@@ -438,6 +443,9 @@ func (c *Client) GenerateVirtualMachine(vm *migration.VirtualMachineImport) (*ku
 		}
 		if secureboot {
 			firmware.Bootloader.EFI.SecureBoot = &boolTrue
+			vmSpec.Template.Spec.Domain.Features.SMM = &kubevirt.FeatureState{
+				Enabled: &boolTrue,
+			}
 		}
 		vmSpec.Template.Spec.Domain.Firmware = firmware
 		if tpm {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When source vm in openstack is using uefi with secureboot enabled the imported VM in Harvester is unable to start as secureboot needs feature smm to be enabled.

This is already done for vmware sources but was missed for openstack sources.
**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The PR attempts to fix the missing smm feature.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
