### PR TITLE
Do more logging during the import

### DIFF
--- a/pkg/source/openstack/client.go
+++ b/pkg/source/openstack/client.go
@@ -203,13 +203,16 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) error 
 			return err
 		}
 
-		logrus.Info(volObj)
+		logrus.WithFields(logrus.Fields{
+			"name":                    vm.Name,
+			"namespace":               vm.Namespace,
+			"spec.virtualMachineName": vm.Spec.VirtualMachineName,
+			"volume":                  volObj,
+		}).Info("Attempting to create new image from volume")
 
 		if err := volumes.WaitForStatus(c.storageClient, volObj.ID, "available", pollingTimeout); err != nil {
 			return fmt.Errorf("timeout waiting for volumes %v to become available: %v", volObj.ID, err)
 		}
-
-		logrus.Info("attempting to create new image from volume")
 
 		volImage, err := volumeactions.UploadImage(c.storageClient, volObj.ID, volumeactions.UploadImageOpts{
 			ImageName:  fmt.Sprintf("import-controller-%s-%d", vm.Spec.VirtualMachineName, i),


### PR DESCRIPTION
**Problem:**
At the moment there is too little logging, so you never know what status the import is currently in.

**Solution:**
Add log messages to better track what the importer is doing and to better isolate errors if necessary.

```
time="2024-09-05T09:05:45Z" level=info msg="Running preflight checks ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-09-05T09:05:45Z" level=info msg="Importing client disk images ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-09-05T09:05:46Z" level=info msg="Powering off client VM ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-09-05T09:05:48Z" level=info msg="Importing client disk images ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-09-05T09:05:49Z" level=info msg="Importing client disk images ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-09-05T09:05:55Z" level=info msg="Attempting to create new image from volume" name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny volume="&{3ad12a1c-57fe-4dac-88cd-3a17c0d9fcea creating 1 nova 2024-09-05 09:05:55.259378 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ]   lvmdriver-1 a8cea8ac-cf5f-41f1-a57d-817d1a0c95d1  map] ace422d469c04a268af6a3e538d088af true false   false}" volume.id=3ad12a1c-57fe-4dac-88cd-3a17c0d9fcea
time="2024-09-05T09:06:17Z" level=info msg="Creating VM images ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-09-05T09:06:17Z" level=info msg="Evaluating VM images ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-09-05T09:06:17Z" level=info msg="Creating VM instances ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-09-05T09:06:20Z" level=info msg="Checking VM instances ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-09-05T09:11:20Z" level=info msg="Checking VM instances ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-09-05T09:11:20Z" level=info msg="The VM was imported successfully" name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
```

**Related Issue:**
https://github.com/harvester/harvester/issues/6512

**Test plan:**
Import a VM from OpenStack or vSphere and check if the logs of the vm-import-controller look like the example above. Look out for messages like:
- Running preflight checks ...
- Importing client disk images ...
- The VM was imported successfully
- ...
