### PR TITLE
Address network duplication during import process

### DIFF
--- a/pkg/controllers/migration/virtualmachine.go
+++ b/pkg/controllers/migration/virtualmachine.go
@@ -226,6 +226,17 @@ func (h *virtualMachineHandler) preFlightChecks(vm *migration.VirtualMachineImpo
 		}
 	}
 
+	// dedup source network names as the same source network name cannot appear twice
+	sourceNetworkMap := make(map[string]bool)
+	for _, network := range vm.Spec.Mapping {
+		_, ok := sourceNetworkMap[network.SourceNetwork]
+		if !ok {
+			sourceNetworkMap[network.SourceNetwork] = true
+			continue
+		}
+		return fmt.Errorf("source network %s appears multiple times in vm spec", network.SourceNetwork)
+	}
+
 	return nil
 }
 

--- a/pkg/source/openstack/client.go
+++ b/pkg/source/openstack/client.go
@@ -337,23 +337,11 @@ func (c *Client) GenerateVirtualMachine(vm *migration.VirtualMachineImport) (*ku
 		return nil, fmt.Errorf("error getting firware settings: %v", err)
 	}
 
-	var networks []networkInfo
-	for network, values := range vmObj.Addresses {
-		valArr, ok := values.([]interface{})
-		if !ok {
-			return nil, fmt.Errorf("error asserting interface []interface")
-		}
-		for _, v := range valArr {
-			valMap, ok := v.(map[string]interface{})
-			if !ok {
-				return nil, fmt.Errorf("error asserting network array element into map[string]string")
-			}
-			networks = append(networks, networkInfo{
-				NetworkName: network,
-				MAC:         valMap["OS-EXT-IPS-MAC:mac_addr"].(string),
-			})
-		}
+	networks, err := generateNetworkInfo(vmObj.Addresses)
+	if err != nil {
+		return nil, err
 	}
+
 	newVM := &kubevirt.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      vm.Spec.VirtualMachineName,
@@ -639,4 +627,36 @@ func (c *Client) ImageFirmwareSettings(instance *servers.Server) (bool, bool, bo
 		secureBoot = true
 	}
 	return uefiType, tpmEnabled, secureBoot, nil
+}
+
+func generateNetworkInfo(info map[string]interface{}) ([]networkInfo, error) {
+	networks := make([]networkInfo, 0)
+	uniqueNetworks := make([]networkInfo, 0)
+	for network, values := range info {
+		valArr, ok := values.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("error asserting interface []interface")
+		}
+		for _, v := range valArr {
+			valMap, ok := v.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("error asserting network array element into map[string]string")
+			}
+			networks = append(networks, networkInfo{
+				NetworkName: network,
+				MAC:         valMap["OS-EXT-IPS-MAC:mac_addr"].(string),
+			})
+		}
+	}
+	// in case of interfaces with ipv6 and ipv4 addresses they are reported twice, so we need to dedup them
+	// based on a mac address
+	networksMap := make(map[string]networkInfo)
+	for _, v := range networks {
+		networksMap[v.MAC] = v
+	}
+
+	for _, v := range networksMap {
+		uniqueNetworks = append(uniqueNetworks, v)
+	}
+	return uniqueNetworks, nil
 }

--- a/pkg/source/openstack/client_test.go
+++ b/pkg/source/openstack/client_test.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -123,4 +124,17 @@ func Test_GenerateVirtualMachine(t *testing.T) {
 	assert.NotEmpty(newVM.Spec.Template.Spec.Domain.Resources.Limits.Memory(), "expected memory limit to not be empty")
 	assert.NotEmpty(newVM.Spec.Template.Spec.Networks, "expected to find atleast 1 network as pod network should have been applied")
 	assert.NotEmpty(newVM.Spec.Template.Spec.Domain.Devices.Interfaces, "expected to find atleast 1 interface for pod-network")
+}
+
+func Test_generateNetworkInfo(t *testing.T) {
+	networkInfoByte := []byte(`{"private":[{"OS-EXT-IPS-MAC:mac_addr":"fa:16:3e:92:5f:45","OS-EXT-IPS:type":"fixed","addr":"fd5b:731d:94e1:0:f816:3eff:fe92:5f45","version":6},{"OS-EXT-IPS-MAC:mac_addr":"fa:16:3e:92:5f:45","OS-EXT-IPS:type":"fixed","addr":"10.0.0.38","version":4}],"shared":[{"OS-EXT-IPS-MAC:mac_addr":"fa:16:3e:ec:49:11","OS-EXT-IPS:type":"fixed","addr":"192.168.233.233","version":4}]}`)
+	var networkInfoMap map[string]interface{}
+	assert := require.New(t)
+	err := json.Unmarshal(networkInfoByte, &networkInfoMap)
+	assert.NoError(err, "expected no error while unmarshalling network info")
+
+	vmInterfaceDetails, err := generateNetworkInfo(networkInfoMap)
+	assert.NoError(err, "expected no error while generating network info")
+	assert.Len(vmInterfaceDetails, 2, "expected to find 2 interfaces only")
+
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
In case cases as reported by the linked issue, the nic's are duplicated in the imported VM.

There are different causes for this behaviour.

In case of openstack, if the network is dual stacked, then the api reports the network interface details twice, once with ipv4 and ipv6 addressing which causes the additional network mapping to appear. This is now fixed with a dedup of nics based on mac addresses

in case of vmware, this behaviour only happens when the same sourceNetwork appears in the import spec twice, without that multi-homed VM's get imported without any nic duplication. For example the following spec will trigger the duplication of nics. The easy fix is to dedup the source networks during the preflight check to allow the user to fix their network definitions and allow user to correct the spec.

```
apiVersion: migration.harvesterhci.io/v1beta1
kind: VirtualMachineImport
metadata:
  name: ubuntu-import
  namespace: default
spec:
  virtualMachineName: "gm-ubuntu-test"
  networkMapping:
  - sourceNetwork: "VM Network"
    destinationNetwork: "default/workload"
  - sourceNetwork: "VM Network"
    destinationNetwork: "default/workload"
  sourceCluster:
    name: wrangler
    namespace: default
    kind: VmwareSource
    apiVersion: migration.harvesterhci.io/v1beta1
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR introduces two minor fixes:
* dedup network info for openstack vm's based on mac addresses to avoid creating a nic in imported VM for each match of source to destination network
* dedup source network for VMs during preflight checks to avoid same nic being mapped twice for the same source network

**Related Issue:**
https://github.com/harvester/harvester/issues/6451
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
