### PR TITLE
Validate the network mapping configuration

### DIFF
--- a/charts/vm-import-controller/templates/rbac.yaml
+++ b/charts/vm-import-controller/templates/rbac.yaml
@@ -26,7 +26,14 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - "*"  
+  - "*"
+- apiGroups:
+    - "k8s.cni.cncf.io"
+  resources:
+    - "network-attachment-definitions"
+  verbs:
+    - "list"
+    - "watch"
 - apiGroups:
   - ""
   resources:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gophercloud/gophercloud v1.11.0
 	github.com/harvester/harvester v1.3.0
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.3.0
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/ory/dockertest/v3 v3.9.1
@@ -65,7 +66,6 @@ require (
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.3.0 // indirect
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	harvester "github.com/harvester/harvester/pkg/generated/controllers/harvesterhci.io"
+	cniv1 "github.com/harvester/harvester/pkg/generated/controllers/k8s.cni.cncf.io"
 	"github.com/harvester/harvester/pkg/generated/controllers/kubevirt.io"
 	"github.com/rancher/lasso/pkg/cache"
 	"github.com/rancher/lasso/pkg/client"
@@ -86,13 +87,20 @@ func Register(ctx context.Context, restConfig *rest.Config) error {
 
 	scCache := storageFactory.Storage().V1().StorageClass().Cache()
 
+	cniFactory, err := cniv1.NewFactoryFromConfigWithOptions(restConfig, &core.FactoryOptions{
+		SharedControllerFactory: scf,
+	})
+	if err != nil {
+		return err
+	}
+
 	sc.RegisterVmwareController(ctx, migrationFactory.Migration().V1beta1().VmwareSource(), coreFactory.Core().V1().Secret())
 	sc.RegisterOpenstackController(ctx, migrationFactory.Migration().V1beta1().OpenstackSource(), coreFactory.Core().V1().Secret())
 
 	sc.RegisterVMImportController(ctx, migrationFactory.Migration().V1beta1().VmwareSource(), migrationFactory.Migration().V1beta1().OpenstackSource(),
 		coreFactory.Core().V1().Secret(), migrationFactory.Migration().V1beta1().VirtualMachineImport(),
 		harvesterFactory.Harvesterhci().V1beta1().VirtualMachineImage(), kubevirtFactory.Kubevirt().V1().VirtualMachine(),
-		coreFactory.Core().V1().PersistentVolumeClaim(), scCache)
+		coreFactory.Core().V1().PersistentVolumeClaim(), scCache, cniFactory.K8s().V1().NetworkAttachmentDefinition().Cache())
 
-	return start.All(ctx, 1, migrationFactory, coreFactory, harvesterFactory, kubevirtFactory, storageFactory)
+	return start.All(ctx, 1, migrationFactory, coreFactory, harvesterFactory, kubevirtFactory, storageFactory, cniFactory)
 }

--- a/pkg/source/openstack/client.go
+++ b/pkg/source/openstack/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -163,6 +164,16 @@ func (c *Client) Verify() error {
 	}
 
 	logrus.Infof("found %d servers", len(allServers))
+	return nil
+}
+
+func (c *Client) PreFlightChecks(vm *migration.VirtualMachineImport) (err error) {
+	for _, nm := range vm.Spec.Mapping {
+		_, err := networks.Get(c.computeClient, nm.SourceNetwork).Extract()
+		if err != nil {
+			return fmt.Errorf("error getting source network '%s': %v", nm.SourceNetwork, err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/source/vmware/client.go
+++ b/pkg/source/vmware/client.go
@@ -123,6 +123,23 @@ func (c *Client) Verify() error {
 	return nil
 }
 
+func (c *Client) PreFlightChecks(vm *migration.VirtualMachineImport) (err error) {
+	f := find.NewFinder(c.Client.Client, true)
+	dc := c.dc
+	if !strings.HasPrefix(c.dc, "/") {
+		dc = fmt.Sprintf("/%s", c.dc)
+	}
+	for _, nm := range vm.Spec.Mapping {
+		// The path looks like `/<datacenter>/network/<network-name>`.
+		path := filepath.Join(dc, "/network", nm.SourceNetwork)
+		_, err := f.Network(c.ctx, path)
+		if err != nil {
+			return fmt.Errorf("error getting source network '%s': %v", nm.SourceNetwork, err)
+		}
+	}
+	return nil
+}
+
 func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) (err error) {
 	var (
 		tmpPath string

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -20,6 +20,8 @@ import (
 	log "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	k8scnicncfiov1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
 	migration "github.com/harvester/vm-import-controller/pkg/apis/migration.harvesterhci.io/v1beta1"
 	"github.com/harvester/vm-import-controller/pkg/controllers"
 	"github.com/harvester/vm-import-controller/pkg/server"
@@ -81,8 +83,9 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{}
 
 	if !useExisting {
-		crds, err := setup.GenerateKubeVirtCRD()
+		crds, err := setup.GenerateCRD()
 		Expect(err).ToNot(HaveOccurred())
+
 		testEnv.CRDInstallOptions = envtest.CRDInstallOptions{
 			CRDs: crds,
 		}
@@ -105,6 +108,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = kubevirtv1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = k8scnicncfiov1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})

--- a/tests/setup/harvester_mock.go
+++ b/tests/setup/harvester_mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 
@@ -11,8 +12,8 @@ import (
 	"github.com/harvester/harvester/pkg/util/crd"
 )
 
-// InstallCRD will install the core harvester CRD's
-// copied from harvester/harvester/pkg/data/crd.go
+// InstallCRD will install the core Harvester CRD's
+// partly copied from harvester/harvester/pkg/data/crd.go
 func InstallCRD(ctx context.Context, cfg *rest.Config) error {
 	factory, err := crd.NewFactoryFromClient(ctx, cfg)
 	if err != nil {
@@ -37,10 +38,23 @@ func InstallCRD(ctx context.Context, cfg *rest.Config) error {
 		BatchWait()
 }
 
+// GenerateCRD will generate other required CRD's
+func GenerateCRD() ([]*extv1.CustomResourceDefinition, error) {
+	kubeVirtCrds, err := generateKubeVirtCRD()
+	if err != nil {
+		return nil, err
+	}
+	k8sCniCncfIoCrds, err := generateK8sCniCncfIoCRD()
+	if err != nil {
+		return nil, err
+	}
+	return append(kubeVirtCrds, k8sCniCncfIoCrds...), nil
+}
+
 type kubeVirtCRDGenerator func() (*extv1.CustomResourceDefinition, error)
 
-// GenerateKubeVirtCRD's will generate kubevirt CRDs
-func GenerateKubeVirtCRD() ([]*extv1.CustomResourceDefinition, error) {
+// generateKubeVirtCRD will generate kubevirt CRDs
+func generateKubeVirtCRD() ([]*extv1.CustomResourceDefinition, error) {
 	v := []kubeVirtCRDGenerator{
 		components.NewVirtualMachineCrd,
 		components.NewVirtualMachineInstanceCrd,
@@ -63,5 +77,54 @@ func GenerateKubeVirtCRD() ([]*extv1.CustomResourceDefinition, error) {
 		results = append(results, crdList)
 	}
 
+	return results, nil
+}
+
+// generateK8sCniCncfIoCRD will generate k8s.cni.cncf.io CRDs
+func generateK8sCniCncfIoCRD() ([]*extv1.CustomResourceDefinition, error) {
+	var results []*extv1.CustomResourceDefinition
+	results = append(results,
+		// See https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/blob/v1.3.0/artifacts/networks-crd.yaml
+		&extv1.CustomResourceDefinition{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: extv1.SchemeGroupVersion.String(),
+				Kind:       "CustomResourceDefinition",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "network-attachment-definitions.k8s.cni.cncf.io",
+			},
+			Spec: extv1.CustomResourceDefinitionSpec{
+				Group: "k8s.cni.cncf.io",
+				Scope: "Namespaced",
+				Names: extv1.CustomResourceDefinitionNames{
+					Plural:     "network-attachment-definitions",
+					Singular:   "network-attachment-definition",
+					Kind:       "NetworkAttachmentDefinition",
+					ShortNames: []string{"net-attach-def"},
+				},
+				Versions: []extv1.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1",
+						Served:  true,
+						Storage: true,
+						Schema: &extv1.CustomResourceValidation{
+							OpenAPIV3Schema: &extv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]extv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]extv1.JSONSchemaProps{
+											"config": {
+												Type: "string",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
 	return results, nil
 }


### PR DESCRIPTION
**Problem:**
The VM import does not check if the specified source and destination networks exist.

**Solution:**
During the preflight checks do a lookup on the specified networks.

- A new `apiGroups` is added to the `ClusterRole` to be able to list `network-attachment-definitions`.
- The `network-attachment-definitions` CRD has to be generated in the test env.

**Related Issue:**
https://github.com/harvester/harvester/issues/6491

**Test plan:**
# Case 1
- Create the following manifest and apply it. Make sure the destination network `default/vlan2` should not exist in Harvester.
```
apiVersion: migration.harvesterhci.io/v1beta1
kind: VirtualMachineImport
metadata:
  name: cirros-tiny
  namespace: default
spec:
  virtualMachineName: "cirros-tiny"
  networkMapping:
  - sourceNetwork: "shared"
    destinationNetwork: "default/vlan2"
  sourceCluster:
    name: devstack
    namespace: default
    kind: OpenstackSource
    apiVersion: migration.harvesterhci.io/v1beta1
```
- The log output should look like this:
```
...
time="2024-09-26T07:21:30Z" level=info msg="Reconciling migration source" kind=VmwareSource name=vcsim namespace=default
time="2024-09-26T07:21:30Z" level=info msg="Starting migration.harvesterhci.io/v1beta1, Kind=OpenstackSource controller"
time="2024-09-26T07:21:30Z" level=info msg="Reconciling migration source" kind=OpenstackSource name=devstack namespace=default
time="2024-09-26T07:21:30Z" level=info msg="Starting k8s.cni.cncf.io/v1, Kind=NetworkAttachmentDefinition controller"
time="2024-09-26T07:22:29Z" level=info msg="Running preflight checks ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-09-26T07:22:29Z" level=error msg="Failed to get destination network 'default/vlan2': network-attachment-definitions.k8s.cni.cncf.io \"vlan2\" not found" name=cirros-tiny namespace=default spec.sourcecluster.kind=OpenstackSource
time="2024-09-26T07:22:29Z" level=error msg="error syncing 'default/cirros-tiny': handler virtualmachine-import-job-change: network-attachment-definitions.k8s.cni.cncf.io \"vlan2\" not found, requeuing"
...
```

# Case 2
- Create the following manifest and apply it. Make sure the source network `foo` should not exist in OpenStack.
```
apiVersion: migration.harvesterhci.io/v1beta1
kind: VirtualMachineImport
metadata:
  name: cirros-tiny
  namespace: default
spec:
  virtualMachineName: "cirros-tiny"
  networkMapping:
  - sourceNetwork: "foo"
    destinationNetwork: "default/vlan1"
  sourceCluster:
    name: devstack
    namespace: default
    kind: OpenstackSource
    apiVersion: migration.harvesterhci.io/v1beta1
```
- The log output should look like this:
```
...
time="2024-09-26T07:31:29Z" level=info msg="Reconciling migration source" kind=OpenstackSource name=devstack namespace=default
time="2024-09-26T07:31:29Z" level=info msg="Starting migration.harvesterhci.io/v1beta1, Kind=VirtualMachineImport controller"
time="2024-09-26T07:31:29Z" level=info msg="Starting storage.k8s.io/v1, Kind=StorageClass controller"
time="2024-09-26T07:31:29Z" level=info msg="Starting migration.harvesterhci.io/v1beta1, Kind=VmwareSource controller"
time="2024-09-26T07:31:29Z" level=info msg="Reconciling migration source" kind=VmwareSource name=vcsim namespace=default
time="2024-09-26T07:31:35Z" level=info msg="Running preflight checks ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-09-26T07:31:36Z" level=error msg="Failed to perform source cluster specific preflight checks: error getting source network 'foo': Resource not found: [GET http://xxx/compute/v2.1/networks/foo], error message: {\"message\": \"The resource could not be found.<br /><br />\\n\\n\\n\", \"code\": \"404 Not Found\", \"title\": \"Not Found\"}" name=cirros-tiny namespace=default spec.sourcecluster.kind=OpenstackSource
time="2024-09-26T07:31:36Z" level=error msg="error syncing 'default/cirros-tiny': handler virtualmachine-import-job-change: error getting source network 'foo': Resource not found: [GET http://xxx/compute/v2.1/networks/foo], error message: {\"message\": \"The resource could not be found.<br /><br />\\n\\n\\n\", \"code\": \"404 Not Found\", \"title\": \"Not Found\"}, requeuing"
...
```

# Case 3
- Create the following manifest and apply it. Make sure the source network `VM Network 2` should not exist in Vmware.
```
apiVersion: migration.harvesterhci.io/v1beta1
kind: VirtualMachineImport
metadata:
  name: mr-leap1
  namespace: default
spec: 
  virtualMachineName: "mr-leap1"
  networkMapping:
  - sourceNetwork: "VM Network 2"
    destinationNetwork: "default/vlan1"
  sourceCluster: 
    name: vcsim
    namespace: default
    kind: VmwareSource
    apiVersion: migration.harvesterhci.io/v1beta1
```
- The log output should look like this:
```
...
time="2024-09-26T07:36:33Z" level=info msg="Reconciling migration source" kind=OpenstackSource name=devstack namespace=default
time="2024-09-26T07:36:33Z" level=info msg="Starting migration.harvesterhci.io/v1beta1, Kind=VirtualMachineImport controller"
time="2024-09-26T07:36:33Z" level=info msg="Starting migration.harvesterhci.io/v1beta1, Kind=VmwareSource controller"
time="2024-09-26T07:36:33Z" level=info msg="Starting storage.k8s.io/v1, Kind=StorageClass controller"
time="2024-09-26T07:36:33Z" level=info msg="Reconciling migration source" kind=VmwareSource name=vcsim namespace=default
time="2024-09-26T07:36:43Z" level=info msg="Running preflight checks ..." name=mr-leap1 namespace=default spec.virtualMachineName=mr-leap1
time="2024-09-26T07:36:45Z" level=error msg="Failed to perform source cluster specific preflight checks: error getting source network 'VM Network 2': network '/Datacenter/network/VM Network 2' not found" name=mr-leap1 namespace=default spec.sourcecluster.kind=VmwareSource
time="2024-09-26T07:36:45Z" level=error msg="error syncing 'default/mr-leap1': handler virtualmachine-import-job-change: error getting source network 'VM Network 2': network '/Datacenter/network/VM Network 2' not found, requeuing"
...
```
