### PR TITLE
Make timeout during waiting for uploadImage configurable

### DIFF
--- a/pkg/apis/migration.harvesterhci.io/v1beta1/common.go
+++ b/pkg/apis/migration.harvesterhci.io/v1beta1/common.go
@@ -8,5 +8,10 @@ type SourceInterface interface {
 	ClusterStatus() ClusterStatus
 	SecretReference() corev1.SecretReference
 	GetKind() string
+
+	// GetConnectionInfo returns the connection information of the Source.
 	GetConnectionInfo() (string, string)
+
+	// GetOptions returns the additional configuration options of the Source.
+	GetOptions() interface{}
 }

--- a/pkg/apis/migration.harvesterhci.io/v1beta1/vmware.go
+++ b/pkg/apis/migration.harvesterhci.io/v1beta1/vmware.go
@@ -54,3 +54,7 @@ func (v *VmwareSource) GetKind() string {
 func (v *VmwareSource) GetConnectionInfo() (string, string) {
 	return v.Spec.EndpointAddress, v.Spec.Datacenter
 }
+
+func (v *VmwareSource) GetOptions() interface{} {
+	return nil
+}

--- a/pkg/controllers/migration/openstack.go
+++ b/pkg/controllers/migration/openstack.go
@@ -50,7 +50,7 @@ func (h *openstackHandler) OnSourceChange(_ string, o *migration.OpenstackSource
 			return o, fmt.Errorf("error looking up secret for openstacksource: %v", err)
 		}
 
-		client, err := openstack.NewClient(h.ctx, o.Spec.EndpointAddress, o.Spec.Region, secretObj)
+		client, err := openstack.NewClient(h.ctx, o.Spec.EndpointAddress, o.Spec.Region, secretObj, o.GetOptions().(migration.OpenstackSourceOptions))
 		if err != nil {
 			return o, fmt.Errorf("error generating openstack client for openstack migration: %s: %v", o.Name, err)
 		}

--- a/pkg/controllers/migration/virtualmachine.go
+++ b/pkg/controllers/migration/virtualmachine.go
@@ -407,7 +407,8 @@ func (h *virtualMachineHandler) generateVMO(vm *migration.VirtualMachineImport) 
 
 	if source.GetKind() == strings.ToLower("openstacksource") {
 		endpoint, region := source.GetConnectionInfo()
-		return openstack.NewClient(h.ctx, endpoint, region, secret)
+		options := source.GetOptions().(migration.OpenstackSourceOptions)
+		return openstack.NewClient(h.ctx, endpoint, region, secret, options)
 	}
 
 	return nil, fmt.Errorf("unsupport source kind")


### PR DESCRIPTION
**Problem:**
In VM Import Controller, the timeout after which the VM Import Controller fails (when waiting for uploadImage on OpenStack) is hard-coded to 300s or 5min (30 iterations of a 10s wait loop). 

This should be configurable because the uploadImage OpenStack API Call can take several dozens of minutes if not hours sometimes.

**Solution:**
Add the fields `UploadImageRetryCount` and `UploadImageRetryDelay` to `OpenstackSourceSpec`.

**Related Issue:**
https://github.com/harvester/harvester/issues/6675

**Test plan:**
- Create a `OpenstackSource`. e.g. like this:
```
apiVersion: migration.harvesterhci.io/v1beta1
kind: OpenstackSource
metadata:
  name: foo
  namespace: default
spec:
  endpoint: "http://xxx.xxx.xxx.xxx/identity"
  region: "bar"
  credentials:
    name: foo-credentials
    namespace: default
  UploadImageRetryCount: 50
  uploadImageRetryDelay: 15
```
- Trigger a VM import:
```
apiVersion: migration.harvesterhci.io/v1beta1
kind: VirtualMachineImport
metadata:
  name: cirros-tiny
  namespace: default
spec:
  virtualMachineName: "cirros-tiny"
  networkMapping:
  - sourceNetwork: "shared"
    destinationNetwork: "default/vlan1"
  sourceCluster:
    name: foo
    namespace: default
    kind: OpenstackSource
    apiVersion: migration.harvesterhci.io/v1beta1
```
- The log output should look like this. Escpecially look out for `msg="Waiting for volume to be available" ... retryCount=50 retryDelay=15`.
```
time="2024-10-02T11:36:38Z" level=info msg="Running preflight checks ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-10-02T11:36:38Z" level=info msg="Importing client disk images ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-10-02T11:36:39Z" level=info msg="Powering off client VM ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-10-02T11:36:41Z" level=info msg="Importing client disk images ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-10-02T11:36:43Z" level=info msg="Importing client disk images ..." name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2024-10-02T11:36:48Z" level=info msg="Waiting for volume to be available" name=cirros-tiny namespace=default retryCount=50 retryDelay=15 spec.virtualMachineName=cirros-tiny volume.createdAt="2024-10-02 11:36:48.687611 +0000 UTC" volume.id=fcf7e2da-bdd8-4c24-9ff3-7b8faff3554c volume.size=1 volume.snapshotID=56aa80a7-3c60-4812-ad49-144bf43a8ddf volume.status=creating
```
