### PR TITLE
Check image name length in preflight phase

### DIFF
--- a/pkg/apis/migration.harvesterhci.io/v1beta1/virtualmachines.go
+++ b/pkg/apis/migration.harvesterhci.io/v1beta1/virtualmachines.go
@@ -21,11 +21,18 @@ type VirtualMachineImport struct {
 
 // VirtualMachineImportSpec is used to create kubevirt VirtualMachines by exporting VM's from migration clusters.
 type VirtualMachineImportSpec struct {
-	SourceCluster      corev1.ObjectReference `json:"sourceCluster"`
-	VirtualMachineName string                 `json:"virtualMachineName"`
-	Folder             string                 `json:"folder,omitempty"`
-	Mapping            []NetworkMapping       `json:"networkMapping,omitempty"` //If empty new VirtualMachineImport will be mapped to Management Network
-	StorageClass       string                 `json:"storageClass,omitempty"`
+	SourceCluster corev1.ObjectReference `json:"sourceCluster"`
+
+	// VirtualMachineName is the name of the virtual machine that will be
+	// imported. It contains the name or ID of the source virtual machine.
+	// Note that these names may not be DNS1123 compliant and will therefore
+	// be sanitized later.
+	// Examples: "vm-1234", "my-VM" or "5649cac7-3871-4bb5-aab6-c72b8c18d0a2"
+	VirtualMachineName string `json:"virtualMachineName"`
+
+	Folder       string           `json:"folder,omitempty"`
+	Mapping      []NetworkMapping `json:"networkMapping,omitempty"` //If empty new VirtualMachineImport will be mapped to Management Network
+	StorageClass string           `json:"storageClass,omitempty"`
 }
 
 // VirtualMachineImportStatus tracks the status of the VirtualMachineImport export from migration and import into the Harvester cluster
@@ -34,6 +41,11 @@ type VirtualMachineImportStatus struct {
 	DiskImportStatus  []DiskInfo         `json:"diskImportStatus,omitempty"`
 	ImportConditions  []common.Condition `json:"importConditions,omitempty"`
 	NewVirtualMachine string             `json:"newVirtualMachine,omitempty"`
+
+	// DefiniteVirtualMachineName is the sanitized and definite name of the
+	// target virtual machine that will be created in the Harvester cluster.
+	// The name is DNS1123 compliant.
+	DefiniteVirtualMachineName string `json:"definiteVirtualMachineName,omitempty"`
 }
 
 // DiskInfo contains the information about associated Disk in the Import migration.
@@ -70,14 +82,14 @@ const (
 	DiskImagesFailed              ImportStatus   = "diskImageFailed"
 	VirtualMachineCreated         ImportStatus   = "virtualMachineCreated"
 	VirtualMachineRunning         ImportStatus   = "virtualMachineRunning"
-	VirtualMachineInvalid         ImportStatus   = "virtualMachineInvalid"
+	VirtualMachineImportValid     ImportStatus   = "virtualMachineImportValid"
+	VirtualMachineImportInvalid   ImportStatus   = "virtualMachineImportInvalid"
 	VirtualMachinePoweringOff     condition.Cond = "VMPoweringOff"
 	VirtualMachinePoweredOff      condition.Cond = "VMPoweredOff"
 	VirtualMachineExported        condition.Cond = "VMExported"
 	VirtualMachineImageSubmitted  condition.Cond = "VirtualMachineImageSubmitted"
 	VirtualMachineImageReady      condition.Cond = "VirtualMachineImageReady"
 	VirtualMachineImageFailed     condition.Cond = "VirtualMachineImageFailed"
-	NotValidDNS1123Label          string         = "not a valid DNS1123 label"
 	VirtualMachineExportFailed    condition.Cond = "VMExportFailed"
 	VirtualMachineMigrationFailed ImportStatus   = "VMMigrationFailed"
 )

--- a/pkg/controllers/migration/openstack.go
+++ b/pkg/controllers/migration/openstack.go
@@ -33,7 +33,7 @@ func RegisterOpenstackController(ctx context.Context, os migrationController.Ope
 	os.OnChange(ctx, "openstack-migration-change", oHandler.OnSourceChange)
 }
 
-func (h *openstackHandler) OnSourceChange(_ string, o *migration.OpenstackSource) (*migration.OpenstackSource, error) {
+func (h *openstackHandler) OnSourceChange(key string, o *migration.OpenstackSource) (*migration.OpenstackSource, error) {
 	if o == nil || o.DeletionTimestamp != nil {
 		return o, nil
 	}
@@ -42,7 +42,9 @@ func (h *openstackHandler) OnSourceChange(_ string, o *migration.OpenstackSource
 		"kind":      o.Kind,
 		"name":      o.Name,
 		"namespace": o.Namespace,
-	}).Info("Reconciling migration source")
+		"key":       key,
+	}).Info("Reconciling source")
+
 	if o.Status.Status != migration.ClusterReady {
 		// process migration logic
 		secretObj, err := h.secret.Get(o.Spec.Credentials.Namespace, o.Spec.Credentials.Name, metav1.GetOptions{})
@@ -52,7 +54,7 @@ func (h *openstackHandler) OnSourceChange(_ string, o *migration.OpenstackSource
 
 		client, err := openstack.NewClient(h.ctx, o.Spec.EndpointAddress, o.Spec.Region, secretObj, o.GetOptions().(migration.OpenstackSourceOptions))
 		if err != nil {
-			return o, fmt.Errorf("error generating openstack client for openstack migration: %s: %v", o.Name, err)
+			return o, fmt.Errorf("error generating openstack client for openstack migration '%s': %v", o.Name, err)
 		}
 
 		err = client.Verify()

--- a/pkg/source/vmware/client.go
+++ b/pkg/source/vmware/client.go
@@ -226,7 +226,7 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) (err e
 	// once the disks are converted this needs to be updated to ".img"
 	// spec for how download_url is generated
 	// 				Spec: harvesterv1beta1.VirtualMachineImageSpec{
-	//					DisplayName: fmt.Sprintf("vm-import-%s-%s", vm.Name, d.Name),
+	//					DisplayName: fmt.Sprintf("vm-import-%s", d.Name),
 	//					URL: fmt.Sprintf("http://%s:%d/%s.img", server.Address(), server.DefaultPort(), d.Name),
 	//				},
 
@@ -238,7 +238,7 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) (err e
 		destFile := filepath.Join(server.TempDir(), rawDiskName)
 		err = qemu.ConvertVMDKtoRAW(sourceFile, destFile)
 		if err != nil {
-			return fmt.Errorf("error during conversion of vmdk to raw disk %v", err)
+			return fmt.Errorf("error during conversion of vmdk to raw disk: %v", err)
 		}
 		// update fields to reflect final location of raw image file
 		vm.Status.DiskImportStatus[i].DiskLocalPath = server.TempDir()

--- a/tests/integration/common_test.go
+++ b/tests/integration/common_test.go
@@ -78,11 +78,11 @@ var _ = Describe("perform valid dns names", func() {
 					return err
 				}
 
-				if vmObj.Status.Status == migration.VirtualMachineInvalid {
+				if vmObj.Status.Status == migration.VirtualMachineImportInvalid {
 					return nil
 				}
 
-				return fmt.Errorf("waiiting for vm obj to be marked invalid")
+				return fmt.Errorf("waiting for vm obj to be marked invalid")
 			}, "30s", "5s").ShouldNot(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
... to ensure the resulting name of the `VirtualMachineImage` will match the 63 characters limit.

- Shorten the image display name from `<VMName>-<VMName>-<DiskIndex>` to the name of the disk `<VMName>-<DiskIndex>` to safe characters. This allows the import of VM with longer names.

Signed-off-by: Volker Theile <vtheile@suse.com>

**Problem:**
There's no way for users to know if VM import is failing due to exceeding naming character limit.

**Solution:**
Check if the expected image name is not exceeding the linit during the preflight phase.

**Related Issue:**
https://github.com/harvester/harvester/issues/6463

**Test plan:**
ToDo...
