### PR TITLE
Use network service client to query source network

### DIFF
--- a/pkg/source/vmware/client.go
+++ b/pkg/source/vmware/client.go
@@ -124,12 +124,19 @@ func (c *Client) Verify() error {
 }
 
 func (c *Client) PreFlightChecks(vm *migration.VirtualMachineImport) (err error) {
+	// Check the source network mappings.
 	f := find.NewFinder(c.Client.Client, true)
 	dc := c.dc
 	if !strings.HasPrefix(c.dc, "/") {
 		dc = fmt.Sprintf("/%s", c.dc)
 	}
 	for _, nm := range vm.Spec.Mapping {
+		logrus.WithFields(logrus.Fields{
+			"name":          vm.Name,
+			"namespace":     vm.Namespace,
+			"sourceNetwork": nm.SourceNetwork,
+		}).Info("Checking the source network as part of the preflight checks")
+
 		// The path looks like `/<datacenter>/network/<network-name>`.
 		path := filepath.Join(dc, "/network", nm.SourceNetwork)
 		_, err := f.Network(c.ctx, path)
@@ -137,6 +144,7 @@ func (c *Client) PreFlightChecks(vm *migration.VirtualMachineImport) (err error)
 			return fmt.Errorf("error getting source network '%s': %v", nm.SourceNetwork, err)
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Problem:**
During the preflight check the VM importer tries to make sure the specified `spec.networkMapping[x].sourceNetwork` in VirtualMachineImport exists for OpenStack imports.
The existing implementation seems not to work anymore with the latest OpenStack versions.

**Solution:**
Make use of the NewNetworkV2 ServiceClient to query for the specified source network.

**Related Issue:**
https://github.com/harvester/harvester/issues/7432

**Test plan:**
***Case 1***
The test plan makes use of our internal OpenStack test environment.
- Create the `Secret` and `OpenstackSource` resources to be able to access the test environment.
```
apiVersion: migration.harvesterhci.io/v1beta1
kind: OpenstackSource
metadata:
  name: devstack
  namespace: default
spec:
  endpoint: "http://xxx.xxx.xxx.xxx/identity"
  region: "RegionX"
  credentials:
    name: devstack-credentials
    namespace: default
```
- Create the following manifest and apply it. Make sure the destination network `default/vlan1` exists in Harvester.
```
apiVersion: migration.harvesterhci.io/v1beta1
kind: VirtualMachineImport
metadata:
  name: random-vm-test
  namespace: default
spec:
  virtualMachineName: "random-VM-test"
  networkMapping:
  - sourceNetwork: "shared"
    destinationNetwork: "default/vlan1"
  sourceCluster:
    name: devstack
    namespace: default
    kind: OpenstackSource
    apiVersion: migration.harvesterhci.io/v1beta1
```
- The import should be successful.