### PR TITLE
fix: Allow ClusterRole harvester-vm-import-controller to list and watch Storage

### DIFF
--- a/charts/vm-import-controller/templates/rbac.yaml
+++ b/charts/vm-import-controller/templates/rbac.yaml
@@ -41,7 +41,13 @@ rules:
   - persistentvolumeclaims
   verbs:
   - "*"
-
+- apiGroups:                                                                                                                                          
+  - storage.k8s.io                                                                                                                                    
+  resources:                                                                                                                                          
+  - "*"                                                                                                                                               
+  verbs:                                                                                                                                              
+  - list                                                                                                                                              
+  - watch  
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
* allow ClusterRole to have RBAC storage to avoid errors in vm-import-controller deployment, when running off of main-head

Resolves: fix/avoid-storageclass-rbac-errors

**Problem:**
Add more permissions in rules for ClusterRole for harvester-vm-import-controller-role

**Solution:**
Adding more permissions for storage.k8s.io, fixes the controller log issues listed in 7543

**Related Issue:**
- https://github.com/harvester/harvester/issues/7543

**Test plan:**
Validate at the deployment/harvester-vm-import-controller that there are no errors in the logs when the pod starts up running the image's `main-head` version on v1.5.0-dev-20250203