### PR TITLE
SMM is not enabled when TPM is enabled in VMware source client

### DIFF
--- a/pkg/source/helper.go
+++ b/pkg/source/helper.go
@@ -1,0 +1,28 @@
+package source
+
+import (
+	"k8s.io/utils/pointer"
+	kubevirt "kubevirt.io/api/core/v1"
+)
+
+func VMSpecSetupUEFISettings(vmSpec *kubevirt.VirtualMachineSpec, secureBoot, tpm bool) {
+	firmware := &kubevirt.Firmware{
+		Bootloader: &kubevirt.Bootloader{
+			EFI: &kubevirt.EFI{
+				SecureBoot: pointer.Bool(false),
+			},
+		},
+	}
+	if secureBoot {
+		firmware.Bootloader.EFI.SecureBoot = pointer.Bool(true)
+	}
+	vmSpec.Template.Spec.Domain.Firmware = firmware
+	if tpm {
+		vmSpec.Template.Spec.Domain.Devices.TPM = &kubevirt.TPMDevice{}
+	}
+	if secureBoot || tpm {
+		vmSpec.Template.Spec.Domain.Features.SMM = &kubevirt.FeatureState{
+			Enabled: pointer.Bool(true),
+		}
+	}
+}

--- a/pkg/source/helper_test.go
+++ b/pkg/source/helper_test.go
@@ -1,0 +1,58 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	kubevirt "kubevirt.io/api/core/v1"
+)
+
+func Test_vmSpecSetupUefiSettings(t *testing.T) {
+	assert := require.New(t)
+	testCases := []struct {
+		desc       string
+		secureBoot bool
+		tpm        bool
+	}{
+		{
+			desc:       "SecureBoot enabled, TPM disabled",
+			secureBoot: true,
+			tpm:        false,
+		}, {
+			desc:       "SecureBoot disabled, TPM enabled",
+			secureBoot: false,
+			tpm:        true,
+		}, {
+			desc:       "SecureBoot enabled, TPM enabled",
+			secureBoot: true,
+			tpm:        true,
+		}, {
+			desc:       "SecureBoot disabled, TPM disabled",
+			secureBoot: false,
+			tpm:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		vmSpec := kubevirt.VirtualMachineSpec{
+			Template: &kubevirt.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirt.VirtualMachineInstanceSpec{
+					Domain: kubevirt.DomainSpec{
+						Features: &kubevirt.Features{},
+					},
+				},
+			},
+		}
+		VMSpecSetupUEFISettings(&vmSpec, tc.secureBoot, tc.tpm)
+		if tc.secureBoot {
+			assert.True(*vmSpec.Template.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot, "expected SecureBoot to be enabled")
+		} else {
+			assert.False(*vmSpec.Template.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot, "expected SecureBoot to be disabled")
+		}
+		if tc.secureBoot || tc.tpm {
+			assert.True(*vmSpec.Template.Spec.Domain.Features.SMM.Enabled, "expected SMM to be enabled")
+		} else {
+			assert.Nil(vmSpec.Template.Spec.Domain.Features.SMM, "expected SMM to be nil")
+		}
+	}
+}


### PR DESCRIPTION
When TPM is enabled, SMM should be enabled as well. The [OpenStack client](https://github.com/harvester/vm-import-controller/blob/5288366b5627f5c750e50ab4b161410cc95230b7/pkg/source/openstack/client.go#L539) part is doing that already, but the [VMware client](https://github.com/harvester/vm-import-controller/blob/29629c75f81f1dfbb0b317d145066acbcc4af899/pkg/source/vmware/client.go#L415) is missing that.

This PR makes also use of the `pointer.BoolXXX()` helper functions to secure de-referencing of nil pointers.

Related to: https://github.com/harvester/harvester/issues/7984