### PR TITLE
[ENHANCEMENT] Improve auto-detection of the disk bus type of the VMware importer

### DIFF
--- a/pkg/apis/migration.harvesterhci.io/v1beta1/virtualmachines.go
+++ b/pkg/apis/migration.harvesterhci.io/v1beta1/virtualmachines.go
@@ -42,6 +42,12 @@ type VirtualMachineImportSpec struct {
 	DefaultNetworkInterfaceModel *string `json:"defaultNetworkInterfaceModel,omitempty" wrangler:"type=string,options=e1000|e1000e|ne2k_pci|pcnet|rtl8139|virtio"`
 
 	StorageClass string `json:"storageClass,omitempty"`
+
+	// The bus type that is used for imported disks if auto-detection fails.
+	// Note, the OpenStack source client does not support auto-detection,
+	// therefore it always makes use of this field.
+	// Defaults to "virtio".
+	DefaultDiskBusType *kubevirtv1.DiskBus `json:"defaultDiskBusType,omitempty"`
 }
 
 // VirtualMachineImportStatus tracks the status of the VirtualMachineImport export from migration and import into the Harvester cluster
@@ -117,6 +123,10 @@ const (
 	NetworkInterfaceModelRtl8139 = "rtl8139"
 	NetworkInterfaceModelVirtio  = "virtio"
 )
+
+func (in *VirtualMachineImport) GetDefaultDiskBusType() kubevirtv1.DiskBus {
+	return ptr.Deref[kubevirtv1.DiskBus](in.Spec.DefaultDiskBusType, kubevirtv1.DiskBusVirtio)
+}
 
 func (in *VirtualMachineImport) GetDefaultNetworkInterfaceModel() string {
 	return ptr.Deref[string](in.Spec.DefaultNetworkInterfaceModel, NetworkInterfaceModelVirtio)

--- a/pkg/source/openstack/client.go
+++ b/pkg/source/openstack/client.go
@@ -375,7 +375,7 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) error 
 			Name:          rawImageFileName,
 			DiskSize:      int64(volObj.Size),
 			DiskLocalPath: server.TempDir(),
-			BusType:       kubevirt.DiskBusVirtio,
+			BusType:       vm.GetDefaultDiskBusType(),
 		})
 	}
 

--- a/pkg/source/vmware/client.go
+++ b/pkg/source/vmware/client.go
@@ -189,6 +189,8 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) (err e
 				i.Path = vm.Name + "-" + vm.Namespace + "-" + i.Path
 			}
 
+			busType := detectBusType(i.DeviceId)
+
 			logrus.WithFields(logrus.Fields{
 				"name":                    vm.Name,
 				"namespace":               vm.Namespace,
@@ -197,6 +199,7 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) (err e
 				"spec.sourceCluster.kind": vm.Spec.SourceCluster.Kind,
 				"deviceId":                i.DeviceId,
 				"path":                    i.Path,
+				"busType":                 busType,
 				"size":                    i.Size,
 			}).Info("Downloading an image")
 
@@ -208,7 +211,7 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) (err e
 			vm.Status.DiskImportStatus = append(vm.Status.DiskImportStatus, migration.DiskInfo{
 				Name:     i.Path,
 				DiskSize: i.Size,
-				BusType:  adapterType(i.DeviceId),
+				BusType:  busType,
 			})
 		} else {
 			logrus.WithFields(logrus.Fields{
@@ -444,14 +447,33 @@ func generateNetworkInfos(devices []types.BaseVirtualDevice) []source.NetworkInf
 	return result
 }
 
-// adapterType tries to identify the disk bus type from vmware
-// to attempt and set correct bus types in kubevirt
-// default is to switch to SATA to ensure device boots
-func adapterType(deviceID string) kubevirt.DiskBus {
-	if strings.Contains(deviceID, "SCSI") {
+// detectBusType tries to identify the disk bus type from VMware to attempt and
+// set correct bus types in kubevirt.
+// Examples:
+// .-----------------------------------------------.
+// | Bus  | Device ID                              |
+// |------|----------------------------------------|
+// | SCSI | /vm-13010/ParaVirtualSCSIController0:0 |
+// | SATA | /vm-13767/VirtualAHCIController0:1     |
+// | IDE  | /vm-5678/VirtualIDEController1:0       |
+// | NVMe | /vm-2468/VirtualNVMEController0:0      |
+// | USB  | /vm-54321/VirtualUSBController0:0      |
+// '-----------------------------------------------'
+func detectBusType(deviceID string) kubevirt.DiskBus {
+	deviceID = strings.ToLower(deviceID)
+	// https://kubevirt.io/api-reference/v1.1.0/definitions.html#_v1_disktarget
+	switch {
+	case strings.Contains(deviceID, "scsi"):
 		return kubevirt.DiskBusSCSI
+	case strings.Contains(deviceID, "ahci"), strings.Contains(deviceID, "sata"), strings.Contains(deviceID, "ide"):
+		return kubevirt.DiskBusSATA
+	case strings.Contains(deviceID, "nvme"):
+		return kubevirt.DiskBusVirtio
+	case strings.Contains(deviceID, "usb"):
+		return kubevirt.DiskBusUSB
+	default:
+		return kubevirt.DiskBusVirtio
 	}
-	return kubevirt.DiskBusSATA
 }
 
 // SanitizeVirtualMachineImport is used to sanitize the VirtualMachineImport object.

--- a/pkg/source/vmware/client.go
+++ b/pkg/source/vmware/client.go
@@ -448,22 +448,39 @@ func generateNetworkInfos(devices []types.BaseVirtualDevice) []source.NetworkInf
 }
 
 // detectBusType tries to identify the disk bus type from VMware to attempt and
-// set correct bus types in kubevirt.
+// set correct bus types in KubeVirt.
 // Examples:
-// .-----------------------------------------------.
-// | Bus  | Device ID                              |
-// |------|----------------------------------------|
-// | SCSI | /vm-13010/ParaVirtualSCSIController0:0 |
-// | SATA | /vm-13767/VirtualAHCIController0:1     |
-// | IDE  | /vm-5678/VirtualIDEController1:0       |
-// | NVMe | /vm-2468/VirtualNVMEController0:0      |
-// | USB  | /vm-54321/VirtualUSBController0:0      |
-// '-----------------------------------------------'
+// .--------------------------------------------------.
+// | Bus  | Device ID                                 |
+// |------|-------------------------------------------|
+// | SCSI | /vm-13010/ParaVirtualSCSIController0:0    |
+// | SCSI | /vm-13011/VirtualBusLogicController0:0    |
+// | SCSI | /vm-13012/VirtualLsiLogicController0:0    |
+// | SCSI | /vm-13013/VirtualLsiLogicSASController0:0 |
+// | SATA | /vm-13767/VirtualAHCIController0:1        |
+// | IDE  | /vm-5678/VirtualIDEController1:0          |
+// | NVMe | /vm-2468/VirtualNVMEController0:0         |
+// | USB  | /vm-54321/VirtualUSBController0:0         |
+// '--------------------------------------------------'
+// References:
+// - https://github.com/vmware/pyvmomi/tree/master/pyVmomi/vim/vm/device
+// - https://vdc-download.vmware.com/vmwb-repository/dcr-public/d1902b0e-d479-46bf-8ac9-cee0e31e8ec0/07ce8dbd-db48-4261-9b8f-c6d3ad8ba472/vim.vm.device.VirtualSCSIController.html
+// - https://libvirt.org/formatdomain.html#controllers
+// - https://kubevirt.io/api-reference/v1.1.0/definitions.html#_v1_disktarget
 func detectBusType(deviceID string) kubevirt.DiskBus {
 	deviceID = strings.ToLower(deviceID)
-	// https://kubevirt.io/api-reference/v1.1.0/definitions.html#_v1_disktarget
 	switch {
-	case strings.Contains(deviceID, "scsi"):
+	case strings.Contains(deviceID, "paravirtualscsi"):
+		// The pvscsi (Paravirtual SCSI) controller cannot be mapped to
+		// SCSI bus type because in KubeVirt it is not possible to specify
+		// the exact model (pvscsi, lsilogic, ...) of the disk via the
+		// VirtualMachine API. Attempting to map pvscsi to SCSI prevents
+		// the VM from booting.
+		// As a workaround, the SATA bus type is utilized in such case.
+		// Note, VirtIO would be better, but it is not said that the
+		// required drivers are installed in the VM.
+		return kubevirt.DiskBusSATA
+	case strings.Contains(deviceID, "scsi"), strings.Contains(deviceID, "buslogic"), strings.Contains(deviceID, "lsilogic"):
 		return kubevirt.DiskBusSCSI
 	case strings.Contains(deviceID, "ahci"), strings.Contains(deviceID, "sata"), strings.Contains(deviceID, "ide"):
 		return kubevirt.DiskBusSATA

--- a/pkg/source/vmware/client_test.go
+++ b/pkg/source/vmware/client_test.go
@@ -398,8 +398,23 @@ func Test_adapterType(t *testing.T) {
 		expected kubevirt.DiskBus
 	}{
 		{
-			desc:     "SCSI disk",
+			desc:     "SCSI disk - VMware Paravirtual",
 			deviceID: "/vm-13010/ParaVirtualSCSIController0:0",
+			expected: kubevirt.DiskBusSATA,
+		},
+		{
+			desc:     "SCSI disk - BusLogic Parallel",
+			deviceID: "/vm-13011/VirtualBusLogicController0:0",
+			expected: kubevirt.DiskBusSCSI,
+		},
+		{
+			desc:     "SCSI disk - LSI Logic Parallel",
+			deviceID: "/vm-13012/VirtualLsiLogicController0:0",
+			expected: kubevirt.DiskBusSCSI,
+		},
+		{
+			desc:     "SCSI disk - LSI Logic SAS",
+			deviceID: "/vm-13013/VirtualLsiLogicSASController0:0",
 			expected: kubevirt.DiskBusSCSI,
 		},
 		{


### PR DESCRIPTION
The IDE disk bus is not supported anymore in the kubevirt version we are using: [kubevirt.io/api-reference/v1.1.0/definitions.html#_v1_disktarget](https://kubevirt.io/api-reference/v1.1.0/definitions.html#_v1_disktarget)

This PR is mapping it to SATA because VirtIO requires the kernel drivers to be installed in the VM which can not be guaranteed.

This is the mapping of the VMware source client:
| Bus  | Example Device ID                         |
|------|-------------------------------------------|
| SCSI | /vm-13010/ParaVirtualSCSIController0:0    |
| SCSI | /vm-13011/VirtualBusLogicController0:0    |
| SCSI | /vm-13012/VirtualLsiLogicController0:0    |
| SCSI | /vm-13013/VirtualLsiLogicSASController0:0 |
| SATA | /vm-13767/VirtualAHCIController0:1        |
| IDE  | /vm-5678/VirtualIDEController1:0          |
| NVMe | /vm-2468/VirtualNVMEController0:0         |
| USB  | /vm-54321/VirtualUSBController0:0         |

The new `DefaultDiskBusType` field in `VirtualMachineImportSpec` allows the user to customize the disk bus type in case the auto-detection fails. Note, the OpenStack source client does not support auto-detection, thus it will always make use of the `DefaultDiskBusType` field if specified. The `DefaultDiskBusType` defaults to `virtio`.

**Related Issue:**
https://github.com/harvester/harvester/issues/7987

**Test plan:**
Use added unit tests.