### PR TITLE
Add option to select network interface model while importing VM

### DIFF
--- a/pkg/apis/migration.harvesterhci.io/v1beta1/virtualmachines.go
+++ b/pkg/apis/migration.harvesterhci.io/v1beta1/virtualmachines.go
@@ -30,9 +30,16 @@ type VirtualMachineImportSpec struct {
 	// Examples: "vm-1234", "my-VM" or "5649cac7-3871-4bb5-aab6-c72b8c18d0a2"
 	VirtualMachineName string `json:"virtualMachineName"`
 
-	Folder       string           `json:"folder,omitempty"`
-	Mapping      []NetworkMapping `json:"networkMapping,omitempty"` //If empty new VirtualMachineImport will be mapped to Management Network
-	StorageClass string           `json:"storageClass,omitempty"`
+	Folder string `json:"folder,omitempty"`
+
+	// If empty new VirtualMachineImport will be mapped to Management Network.
+	Mapping []NetworkMapping `json:"networkMapping,omitempty"`
+	// The Management Network interface model.
+	// This can be one of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.
+	// Defaults to virtio.
+	ManagementNetworkInterfaceModel string `json:"managementNetworkInterfaceModel,omitempty" wrangler:"type=string,default=virtio,options=e1000|e1000e|ne2k_pci|pcnet|rtl8139|virtio"`
+
+	StorageClass string `json:"storageClass,omitempty"`
 }
 
 // VirtualMachineImportStatus tracks the status of the VirtualMachineImport export from migration and import into the Harvester cluster
@@ -70,6 +77,11 @@ type DiskInfo struct {
 type NetworkMapping struct {
 	SourceNetwork      string `json:"sourceNetwork"`
 	DestinationNetwork string `json:"destinationNetwork"`
+	// Override the interface model that is auto-detected or defaulted.
+	// This can be one of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.
+	// When importing VMs from VMware, the interface model is auto-detected.
+	// For OpenStack, it always defaults to `virtio`.
+	InterfaceModel string `json:"interfaceModel,omitempty" wrangler:"type=string,options=e1000|e1000e|ne2k_pci|pcnet|rtl8139|virtio"`
 }
 
 type ImportStatus string

--- a/pkg/source/network.go
+++ b/pkg/source/network.go
@@ -1,0 +1,98 @@
+package source
+
+import (
+	"fmt"
+
+	kubevirt "kubevirt.io/api/core/v1"
+
+	migration "github.com/harvester/vm-import-controller/pkg/apis/migration.harvesterhci.io/v1beta1"
+)
+
+const (
+	NetworkInterfaceModelE1000   = "e1000"
+	NetworkInterfaceModelE1000e  = "e1000e"
+	NetworkInterfaceModelNe2kPci = "ne2k_pci"
+	NetworkInterfaceModelPcnet   = "pcnet"
+	NetworkInterfaceModelRtl8139 = "rtl8139"
+	NetworkInterfaceModelVirtio  = "virtio"
+)
+
+type NetworkInfo struct {
+	NetworkName   string
+	MAC           string
+	MappedNetwork string
+	// This can be one of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.
+	// See https://kubevirt.io/user-guide/network/interfaces_and_networks/#interfaces
+	Model string
+}
+
+func MapNetworkCards(networkInfos []NetworkInfo, networkMappings []migration.NetworkMapping) []NetworkInfo {
+	var result []NetworkInfo
+	for _, ni := range networkInfos {
+		for _, nm := range networkMappings {
+			if nm.SourceNetwork == ni.NetworkName {
+				ni.MappedNetwork = nm.DestinationNetwork
+
+				// Override the auto-detected interface model if it is
+				// customized by the user via the `NetworkMapping` in the
+				// `VirtualMachineImportSpec`.
+				if nm.InterfaceModel != "" {
+					ni.Model = nm.InterfaceModel
+				}
+				// Set a default interface model if none was auto-detected
+				// nor customized by the user.
+				if ni.Model == "" {
+					ni.Model = NetworkInterfaceModelVirtio
+				}
+
+				result = append(result, ni)
+			}
+		}
+	}
+	return result
+}
+
+func GenerateNetworkInterfaceConfig(networkInfos []NetworkInfo, managementNetworkInterfaceModel string) ([]kubevirt.Network, []kubevirt.Interface) {
+	networks := make([]kubevirt.Network, 0, len(networkInfos))
+	interfaces := make([]kubevirt.Interface, 0, len(networkInfos))
+
+	for i, ni := range networkInfos {
+		networks = append(networks, kubevirt.Network{
+			NetworkSource: kubevirt.NetworkSource{
+				Multus: &kubevirt.MultusNetwork{
+					NetworkName: ni.MappedNetwork,
+				},
+			},
+			Name: fmt.Sprintf("migrated-%d", i),
+		})
+
+		interfaces = append(interfaces, kubevirt.Interface{
+			Name:       fmt.Sprintf("migrated-%d", i),
+			MacAddress: ni.MAC,
+			Model:      ni.Model,
+			InterfaceBindingMethod: kubevirt.InterfaceBindingMethod{
+				Bridge: &kubevirt.InterfaceBridge{},
+			},
+		})
+	}
+
+	// If there is no network, attach to Pod network. Essential for VM to
+	// be booted up.
+	if len(networks) == 0 {
+		networks = append(networks, kubevirt.Network{
+			Name: "pod-network",
+			NetworkSource: kubevirt.NetworkSource{
+				Pod: &kubevirt.PodNetwork{},
+			},
+		})
+		interfaces = append(interfaces, kubevirt.Interface{
+			Name:  "pod-network",
+			Model: managementNetworkInterfaceModel,
+			InterfaceBindingMethod: kubevirt.InterfaceBindingMethod{
+				Masquerade: &kubevirt.InterfaceMasquerade{},
+			},
+		})
+	}
+
+	return networks, interfaces
+}

--- a/pkg/source/openstack/client.go
+++ b/pkg/source/openstack/client.go
@@ -31,6 +31,7 @@ import (
 
 	migration "github.com/harvester/vm-import-controller/pkg/apis/migration.harvesterhci.io/v1beta1"
 	"github.com/harvester/vm-import-controller/pkg/server"
+	"github.com/harvester/vm-import-controller/pkg/source"
 )
 
 const (
@@ -479,46 +480,8 @@ func (c *Client) GenerateVirtualMachine(vm *migration.VirtualMachineImport) (*ku
 		},
 	}
 
-	mappedNetwork := mapNetworkCards(networkInfos, vm.Spec.Mapping)
-	networkConfig := make([]kubevirt.Network, 0, len(mappedNetwork))
-	for i, v := range mappedNetwork {
-		networkConfig = append(networkConfig, kubevirt.Network{
-			NetworkSource: kubevirt.NetworkSource{
-				Multus: &kubevirt.MultusNetwork{
-					NetworkName: v.MappedNetwork,
-				},
-			},
-			Name: fmt.Sprintf("migrated-%d", i),
-		})
-	}
-
-	interfaces := make([]kubevirt.Interface, 0, len(mappedNetwork))
-	for i, v := range mappedNetwork {
-		interfaces = append(interfaces, kubevirt.Interface{
-			Name:       fmt.Sprintf("migrated-%d", i),
-			MacAddress: v.MAC,
-			Model:      "virtio",
-			InterfaceBindingMethod: kubevirt.InterfaceBindingMethod{
-				Bridge: &kubevirt.InterfaceBridge{},
-			},
-		})
-	}
-	// if there is no network, attach to Pod network. Essential for VM to be booted up
-	if len(networkConfig) == 0 {
-		networkConfig = append(networkConfig, kubevirt.Network{
-			Name: "pod-network",
-			NetworkSource: kubevirt.NetworkSource{
-				Pod: &kubevirt.PodNetwork{},
-			},
-		})
-		interfaces = append(interfaces, kubevirt.Interface{
-			Name:  "pod-network",
-			Model: "virtio",
-			InterfaceBindingMethod: kubevirt.InterfaceBindingMethod{
-				Masquerade: &kubevirt.InterfaceMasquerade{},
-			},
-		})
-	}
+	mappedNetwork := source.MapNetworkCards(networkInfos, vm.Spec.Mapping)
+	networkConfig, interfaceConfig := source.GenerateNetworkInterfaceConfig(mappedNetwork, vm.Spec.ManagementNetworkInterfaceModel)
 
 	if uefi {
 		firmware := &kubevirt.Firmware{
@@ -544,8 +507,9 @@ func (c *Client) GenerateVirtualMachine(vm *migration.VirtualMachineImport) (*ku
 	}
 
 	vmSpec.Template.Spec.Networks = networkConfig
-	vmSpec.Template.Spec.Domain.Devices.Interfaces = interfaces
+	vmSpec.Template.Spec.Domain.Devices.Interfaces = interfaceConfig
 	newVM.Spec = vmSpec
+
 	// disk attachment needs query by core controller for storage classes, so will be added by the migration controller
 	return newVM, nil
 }
@@ -671,26 +635,6 @@ func (c *Client) findVM(name string) (*ExtendedServer, error) {
 	return &s, err
 }
 
-type networkInfo struct {
-	NetworkName   string
-	MAC           string
-	MappedNetwork string
-}
-
-func mapNetworkCards(networkCards []networkInfo, mapping []migration.NetworkMapping) []networkInfo {
-	var retNetwork []networkInfo
-	for _, nc := range networkCards {
-		for _, m := range mapping {
-			if m.SourceNetwork == nc.NetworkName {
-				nc.MappedNetwork = m.DestinationNetwork
-				retNetwork = append(retNetwork, nc)
-			}
-		}
-	}
-
-	return retNetwork
-}
-
 func (c *Client) ImageFirmwareSettings(instance *servers.Server) (bool, bool, bool, error) {
 	var imageID string
 	var uefiType, tpmEnabled, secureBoot bool
@@ -729,9 +673,9 @@ func (c *Client) ImageFirmwareSettings(instance *servers.Server) (bool, bool, bo
 	return uefiType, tpmEnabled, secureBoot, nil
 }
 
-func generateNetworkInfo(info map[string]interface{}) ([]networkInfo, error) {
-	networkInfos := make([]networkInfo, 0)
-	uniqueNetworks := make([]networkInfo, 0)
+func generateNetworkInfo(info map[string]interface{}) ([]source.NetworkInfo, error) {
+	networkInfos := make([]source.NetworkInfo, 0)
+	uniqueNetworks := make([]source.NetworkInfo, 0)
 	for network, values := range info {
 		valArr, ok := values.([]interface{})
 		if !ok {
@@ -742,15 +686,17 @@ func generateNetworkInfo(info map[string]interface{}) ([]networkInfo, error) {
 			if !ok {
 				return nil, fmt.Errorf("error asserting network array element into map[string]string")
 			}
-			networkInfos = append(networkInfos, networkInfo{
+			networkInfos = append(networkInfos, source.NetworkInfo{
 				NetworkName: network,
 				MAC:         valMap["OS-EXT-IPS-MAC:mac_addr"].(string),
+				// The model is not available via the OpenStack Nova API.
+				Model: source.NetworkInterfaceModelVirtio,
 			})
 		}
 	}
 	// in case of interfaces with ipv6 and ipv4 addresses they are reported twice, so we need to dedup them
 	// based on a mac address
-	networksMap := make(map[string]networkInfo)
+	networksMap := make(map[string]source.NetworkInfo)
 	for _, v := range networkInfos {
 		networksMap[v.MAC] = v
 	}

--- a/pkg/source/openstack/client_test.go
+++ b/pkg/source/openstack/client_test.go
@@ -12,6 +12,7 @@ import (
 
 	migration "github.com/harvester/vm-import-controller/pkg/apis/migration.harvesterhci.io/v1beta1"
 	"github.com/harvester/vm-import-controller/pkg/server"
+	"github.com/harvester/vm-import-controller/pkg/source"
 )
 
 var (
@@ -126,8 +127,9 @@ func Test_GenerateVirtualMachine(t *testing.T) {
 	assert.NoError(err, "expected no error during GenerateVirtualMachine")
 	assert.NotEmpty(newVM.Spec.Template.Spec.Domain.CPU, "expected CPU's to not be empty")
 	assert.NotEmpty(newVM.Spec.Template.Spec.Domain.Resources.Limits.Memory(), "expected memory limit to not be empty")
-	assert.NotEmpty(newVM.Spec.Template.Spec.Networks, "expected to find atleast 1 network as pod network should have been applied")
-	assert.NotEmpty(newVM.Spec.Template.Spec.Domain.Devices.Interfaces, "expected to find atleast 1 interface for pod-network")
+	assert.NotEmpty(newVM.Spec.Template.Spec.Networks, "expected to find at least 1 network as pod network should have been applied")
+	assert.NotEmpty(newVM.Spec.Template.Spec.Domain.Devices.Interfaces, "expected to find at least 1 interface for pod-network")
+	assert.Equal(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].Model, source.NetworkInterfaceModelVirtio, "expected to have a NIC with virtio model")
 }
 
 func Test_generateNetworkInfo(t *testing.T) {
@@ -140,7 +142,8 @@ func Test_generateNetworkInfo(t *testing.T) {
 	vmInterfaceDetails, err := generateNetworkInfo(networkInfoMap)
 	assert.NoError(err, "expected no error while generating network info")
 	assert.Len(vmInterfaceDetails, 2, "expected to find 2 interfaces only")
-
+	assert.Equal(vmInterfaceDetails[0].Model, source.NetworkInterfaceModelVirtio, "expected to have a NIC with virtio model")
+	assert.Equal(vmInterfaceDetails[1].Model, source.NetworkInterfaceModelVirtio, "expected to have a NIC with virtio model")
 }
 
 func Test_ClientOptions(t *testing.T) {

--- a/pkg/source/vmware/client.go
+++ b/pkg/source/vmware/client.go
@@ -26,6 +26,7 @@ import (
 	migration "github.com/harvester/vm-import-controller/pkg/apis/migration.harvesterhci.io/v1beta1"
 	"github.com/harvester/vm-import-controller/pkg/qemu"
 	"github.com/harvester/vm-import-controller/pkg/server"
+	"github.com/harvester/vm-import-controller/pkg/source"
 )
 
 type Client struct {
@@ -316,7 +317,7 @@ func (c *Client) GenerateVirtualMachine(vm *migration.VirtualMachineImport) (*ku
 	}
 
 	// Need CPU, Socket, Memory, VirtualNIC information to perform the mapping
-	networkInfo := identifyNetworkCards(o.Config.Hardware.Device)
+	networkInfos := identifyNetworkCards(o.Config.Hardware.Device)
 
 	vmSpec := kubevirt.VirtualMachineSpec{
 		RunStrategy: &[]kubevirt.VirtualMachineRunStrategy{kubevirt.RunStrategyRerunOnFailure}[0],
@@ -352,49 +353,10 @@ func (c *Client) GenerateVirtualMachine(vm *migration.VirtualMachineImport) (*ku
 		},
 	}
 
-	mappedNetwork := mapNetworkCards(networkInfo, vm.Spec.Mapping)
-	networkConfig := make([]kubevirt.Network, 0, len(mappedNetwork))
-	for i, v := range mappedNetwork {
-		networkConfig = append(networkConfig, kubevirt.Network{
-			NetworkSource: kubevirt.NetworkSource{
-				Multus: &kubevirt.MultusNetwork{
-					NetworkName: v.MappedNetwork,
-				},
-			},
-			Name: fmt.Sprintf("migrated-%d", i),
-		})
-	}
-
-	interfaces := make([]kubevirt.Interface, 0, len(mappedNetwork))
-	for i, v := range mappedNetwork {
-		interfaces = append(interfaces, kubevirt.Interface{
-			Name:       fmt.Sprintf("migrated-%d", i),
-			MacAddress: v.MAC,
-			Model:      "virtio",
-			InterfaceBindingMethod: kubevirt.InterfaceBindingMethod{
-				Bridge: &kubevirt.InterfaceBridge{},
-			},
-		})
-	}
-	// if there is no network, attach to Pod network. Essential for VM to be booted up
-	if len(networkConfig) == 0 {
-		networkConfig = append(networkConfig, kubevirt.Network{
-			Name: "pod-network",
-			NetworkSource: kubevirt.NetworkSource{
-				Pod: &kubevirt.PodNetwork{},
-			},
-		})
-		interfaces = append(interfaces, kubevirt.Interface{
-			Name:  "pod-network",
-			Model: "virtio",
-			InterfaceBindingMethod: kubevirt.InterfaceBindingMethod{
-				Masquerade: &kubevirt.InterfaceMasquerade{},
-			},
-		})
-	}
+	mappedNetwork := source.MapNetworkCards(networkInfos, vm.Spec.Mapping)
+	networkConfig, interfaceConfig := source.GenerateNetworkInterfaceConfig(mappedNetwork, vm.Spec.ManagementNetworkInterfaceModel)
 
 	// setup bios/efi, secureboot and tpm settings
-
 	if o.Config.Firmware == "efi" {
 		firmware := &kubevirt.Firmware{
 			Bootloader: &kubevirt.Bootloader{
@@ -415,9 +377,11 @@ func (c *Client) GenerateVirtualMachine(vm *migration.VirtualMachineImport) (*ku
 			vmSpec.Template.Spec.Domain.Devices.TPM = &kubevirt.TPMDevice{}
 		}
 	}
+
 	vmSpec.Template.Spec.Networks = networkConfig
-	vmSpec.Template.Spec.Domain.Devices.Interfaces = interfaces
+	vmSpec.Template.Spec.Domain.Devices.Interfaces = interfaceConfig
 	newVM.Spec = vmSpec
+
 	// disk attachment needs query by core controller for storage classes, so will be added by the migration controller
 	return newVM, nil
 }
@@ -432,64 +396,56 @@ func (c *Client) findVM(path, name string) (*object.VirtualMachine, error) {
 	return f.VirtualMachine(c.ctx, vmPath)
 }
 
-type networkInfo struct {
-	NetworkName   string
-	MAC           string
-	MappedNetwork string
-}
-
-func identifyNetworkCards(devices []types.BaseVirtualDevice) []networkInfo {
-	var resp []networkInfo
+func identifyNetworkCards(devices []types.BaseVirtualDevice) []source.NetworkInfo {
+	var resp []source.NetworkInfo
 	for _, d := range devices {
 		switch d := d.(type) {
 		case *types.VirtualVmxnet:
 			obj := d
-			resp = append(resp, networkInfo{
+			resp = append(resp, source.NetworkInfo{
 				NetworkName: obj.DeviceInfo.GetDescription().Summary,
 				MAC:         obj.MacAddress,
+				Model:       source.NetworkInterfaceModelVirtio,
 			})
 		case *types.VirtualE1000e:
 			obj := d
-			resp = append(resp, networkInfo{
+			resp = append(resp, source.NetworkInfo{
 				NetworkName: obj.DeviceInfo.GetDescription().Summary,
 				MAC:         obj.MacAddress,
+				Model:       source.NetworkInterfaceModelE1000e,
 			})
 		case *types.VirtualE1000:
 			obj := d
-			resp = append(resp, networkInfo{
+			resp = append(resp, source.NetworkInfo{
 				NetworkName: obj.DeviceInfo.GetDescription().Summary,
 				MAC:         obj.MacAddress,
+				Model:       source.NetworkInterfaceModelE1000,
 			})
 		case *types.VirtualVmxnet3:
 			obj := d
-			resp = append(resp, networkInfo{
+			resp = append(resp, source.NetworkInfo{
 				NetworkName: obj.DeviceInfo.GetDescription().Summary,
 				MAC:         obj.MacAddress,
+				Model:       source.NetworkInterfaceModelVirtio,
 			})
 		case *types.VirtualVmxnet2:
 			obj := d
-			resp = append(resp, networkInfo{
+			resp = append(resp, source.NetworkInfo{
 				NetworkName: obj.DeviceInfo.GetDescription().Summary,
 				MAC:         obj.MacAddress,
+				Model:       source.NetworkInterfaceModelVirtio,
+			})
+		case *types.VirtualPCNet32:
+			obj := d
+			resp = append(resp, source.NetworkInfo{
+				NetworkName: obj.DeviceInfo.GetDescription().Summary,
+				MAC:         obj.MacAddress,
+				Model:       source.NetworkInterfaceModelPcnet,
 			})
 		}
 	}
 
 	return resp
-}
-
-func mapNetworkCards(networkCards []networkInfo, mapping []migration.NetworkMapping) []networkInfo {
-	var retNetwork []networkInfo
-	for _, nc := range networkCards {
-		for _, m := range mapping {
-			if m.SourceNetwork == nc.NetworkName {
-				nc.MappedNetwork = m.DestinationNetwork
-				retNetwork = append(retNetwork, nc)
-			}
-		}
-	}
-
-	return retNetwork
 }
 
 // adapterType tries to identify the disk bus type from vmware

--- a/pkg/source/vmware/client_test.go
+++ b/pkg/source/vmware/client_test.go
@@ -16,6 +16,7 @@ import (
 
 	migration "github.com/harvester/vm-import-controller/pkg/apis/migration.harvesterhci.io/v1beta1"
 	"github.com/harvester/vm-import-controller/pkg/server"
+	"github.com/harvester/vm-import-controller/pkg/source"
 )
 
 var vcsimPort string
@@ -252,7 +253,7 @@ func Test_GenerateVirtualMachine(t *testing.T) {
 	assert.Len(newVM.Spec.Template.Spec.Domain.Devices.Interfaces, 1, "should have found a network map")
 	assert.Equal(newVM.Spec.Template.Spec.Domain.Memory.Guest.String(), "32M", "expected VM to have 32M memory")
 	assert.NotEmpty(newVM.Spec.Template.Spec.Domain.Resources.Limits, "expect to find resource requests to be present")
-
+	assert.Equal(newVM.Spec.Template.Spec.Domain.Devices.Interfaces[0].Model, source.NetworkInterfaceModelE1000, "expected to have a NIC with e1000 model")
 }
 
 func Test_identifyNetworkCards(t *testing.T) {
@@ -294,13 +295,15 @@ func Test_identifyNetworkCards(t *testing.T) {
 		{
 			SourceNetwork:      "DVSwitch: fea97929-4b2d-5972-b146-930c6d0b4014",
 			DestinationNetwork: "pod-network",
+			InterfaceModel:     "rtl8139",
 		},
 	}
 
-	mappedInfo := mapNetworkCards(networkInfo, networkMapping)
+	mappedInfo := source.MapNetworkCards(networkInfo, networkMapping)
 	assert.Len(mappedInfo, 1, "expected to find only 1 item in the mapped networkinfo")
+	assert.Equal(mappedInfo[0].Model, "rtl8139", "expected to have a NIC with rtl8139 model")
 
 	noNetworkMapping := []migration.NetworkMapping{}
-	noMappedInfo := mapNetworkCards(networkInfo, noNetworkMapping)
+	noMappedInfo := source.MapNetworkCards(networkInfo, noNetworkMapping)
 	assert.Len(noMappedInfo, 0, "expected to find no item in the mapped networkinfo")
 }


### PR DESCRIPTION
**Problem:**
The network interface model of an imported VM is set to "VirtIO" by default.

**Solution:**
Add the field `managementNetworkInterfaceModel` to `VirtualMachineImportSpec` and `interfaceModel` to `NetworkMapping` to allow the user to override the auto-detected or defaulted model.

**Related Issue:**
https://github.com/harvester/harvester/issues/7999

**Test plan:**
ToDo
