### PR TITLE
[BUG] No OpenStack resources clean up is done in case of error

### DIFF
--- a/pkg/source/openstack/client.go
+++ b/pkg/source/openstack/client.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	kubevirt "kubevirt.io/api/core/v1"
 
 	migration "github.com/harvester/vm-import-controller/pkg/apis/migration.harvesterhci.io/v1beta1"
@@ -236,13 +237,75 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) error 
 		return err
 	}
 
-	for vIndex, v := range vmObj.AttachedVolumes {
-		imageName := fmt.Sprintf("import-controller-%s-%d", vm.Spec.VirtualMachineName, vIndex)
+	// Helper function to do the export.
+	// This is necessary so that the defer functions are executed at the right
+	// time.
+	exportFn := func(index int, av servers.AttachedVolume) error {
+		var snapshot *snapshots.Snapshot
+		var volume *volumes.Volume
+		var volumeImage volumes.VolumeImage
+
+		imageName := fmt.Sprintf("import-controller-%s-%d", vm.Spec.VirtualMachineName, index)
+
+		// Make sure the snapshot, volume and volume image are cleaned up in any case.
+		defer func() {
+			logrus.WithFields(logrus.Fields{
+				"name":                    vm.Name,
+				"namespace":               vm.Namespace,
+				"spec.virtualMachineName": vm.Spec.VirtualMachineName,
+				"snapshot.id":             ptr.Deref[snapshots.Snapshot](snapshot, snapshots.Snapshot{}).ID,
+				"volume.id":               ptr.Deref[volumes.Volume](volume, volumes.Volume{}).ID,
+				"volumeImage.imageID":     volumeImage.ImageID,
+			}).Info("Cleaning up resources on OpenStack source")
+
+			if len(volumeImage.ImageID) > 0 {
+				if err := images.Delete(c.ctx, c.imageClient, volumeImage.ImageID).ExtractErr(); err != nil {
+					logrus.WithFields(logrus.Fields{
+						"name":                    vm.Name,
+						"namespace":               vm.Namespace,
+						"spec.virtualMachineName": vm.Spec.VirtualMachineName,
+						"image.id":                volumeImage.ImageID,
+					}).Errorf("Failed to delete image: %v", err)
+				}
+			}
+
+			if volume != nil {
+				if err := volumes.Delete(c.ctx, c.storageClient, volume.ID, volumes.DeleteOpts{}).ExtractErr(); err != nil {
+					logrus.WithFields(logrus.Fields{
+						"name":                    vm.Name,
+						"namespace":               vm.Namespace,
+						"spec.virtualMachineName": vm.Spec.VirtualMachineName,
+						"volume.id":               volume.ID,
+					}).Errorf("Failed to delete volume: %v", err)
+				}
+			}
+
+			if snapshot != nil {
+				if err := snapshots.Delete(c.ctx, c.storageClient, snapshot.ID).ExtractErr(); err != nil {
+					logrus.WithFields(logrus.Fields{
+						"name":                    vm.Name,
+						"namespace":               vm.Namespace,
+						"spec.virtualMachineName": vm.Spec.VirtualMachineName,
+						"snapshot.id":             snapshot.ID,
+						"snapshot.name":           snapshot.Name,
+						"snapshot.volumeID":       snapshot.VolumeID,
+					}).Errorf("Failed to delete snapshot: %v", err)
+				}
+			}
+		}()
+
+		logrus.WithFields(logrus.Fields{
+			"name":                    vm.Name,
+			"namespace":               vm.Namespace,
+			"spec.virtualMachineName": vm.Spec.VirtualMachineName,
+			"opts.name":               imageName,
+			"opts.volumeID":           av.ID,
+		}).Info("Creating a new snapshot")
 
 		// create snapshot for volume
-		snapInfo, err := snapshots.Create(c.ctx, c.storageClient, snapshots.CreateOpts{
+		snapshot, err = snapshots.Create(c.ctx, c.storageClient, snapshots.CreateOpts{
 			Name:     imageName,
-			VolumeID: v.ID,
+			VolumeID: av.ID,
 			Force:    true,
 		}).Extract()
 		// snapshot creation is async, so call returns a 202 error when successful.
@@ -255,21 +318,22 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) error 
 			"name":                    vm.Name,
 			"namespace":               vm.Namespace,
 			"spec.virtualMachineName": vm.Spec.VirtualMachineName,
-			"snapshot.id":             snapInfo.ID,
-			"snapshot.name":           snapInfo.Name,
-			"snapshot.size":           snapInfo.Size,
+			"snapshot.id":             snapshot.ID,
+			"snapshot.name":           snapshot.Name,
+			"snapshot.volumeID":       snapshot.VolumeID,
+			"snapshot.size":           snapshot.Size,
 		}).Info("Waiting for snapshot to be available")
 
 		ctxWithTimeout1, cancel1 := context.WithTimeout(c.ctx, pollingTimeout)
 		defer cancel1()
 
-		if err := snapshots.WaitForStatus(ctxWithTimeout1, c.storageClient, snapInfo.ID, "available"); err != nil {
-			return fmt.Errorf("timeout waiting for snapshot %s to be available: %v", snapInfo.ID, err)
+		if err := snapshots.WaitForStatus(ctxWithTimeout1, c.storageClient, snapshot.ID, "available"); err != nil {
+			return fmt.Errorf("timeout waiting for snapshot %s to be available: %w", snapshot.ID, err)
 		}
 
-		volObj, err := volumes.Create(c.ctx, c.storageClient, volumes.CreateOpts{
-			SnapshotID: snapInfo.ID,
-			Size:       snapInfo.Size,
+		volume, err = volumes.Create(c.ctx, c.storageClient, volumes.CreateOpts{
+			SnapshotID: snapshot.ID,
+			Size:       snapshot.Size,
 		}, nil).Extract()
 		if err != nil {
 			return err
@@ -279,11 +343,11 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) error 
 			"name":                    vm.Name,
 			"namespace":               vm.Namespace,
 			"spec.virtualMachineName": vm.Spec.VirtualMachineName,
-			"volume.id":               volObj.ID,
-			"volume.createdAt":        volObj.CreatedAt,
-			"volume.snapshotID":       volObj.SnapshotID,
-			"volume.size":             volObj.Size,
-			"volume.status":           volObj.Status,
+			"volume.id":               volume.ID,
+			"volume.createdAt":        volume.CreatedAt,
+			"volume.snapshotID":       volume.SnapshotID,
+			"volume.size":             volume.Size,
+			"volume.status":           volume.Status,
 			"retryCount":              c.options.UploadImageRetryCount,
 			"retryDelay":              c.options.UploadImageRetryDelay,
 		}).Info("Waiting for volume to be available")
@@ -291,92 +355,103 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) error 
 		ctxWithTimeout2, cancel2 := context.WithTimeout(c.ctx, pollingTimeout)
 		defer cancel2()
 
-		if err := volumes.WaitForStatus(ctxWithTimeout2, c.storageClient, volObj.ID, "available"); err != nil {
-			return fmt.Errorf("timeout waiting for volume %s to be available: %v", volObj.ID, err)
+		if err := volumes.WaitForStatus(ctxWithTimeout2, c.storageClient, volume.ID, "available"); err != nil {
+			return fmt.Errorf("timeout waiting for volume %s to be available: %w", volume.ID, err)
 		}
 
 		logrus.WithFields(logrus.Fields{
 			"name":                    vm.Name,
 			"namespace":               vm.Namespace,
 			"spec.virtualMachineName": vm.Spec.VirtualMachineName,
-			"spec.sourceCluster.name": vm.Spec.SourceCluster.Name,
-			"spec.sourceCluster.kind": vm.Spec.SourceCluster.Kind,
-			"attachedVolumeID":        v.ID,
+			"volume.id":               volume.ID,
+			"opts.imagename":          imageName,
 		}).Info("Creating a new image from a volume")
 
-		volImage, err := volumes.UploadImage(c.ctx, c.storageClient, volObj.ID, volumes.UploadImageOpts{
+		volumeImage, err = volumes.UploadImage(c.ctx, c.storageClient, volume.ID, volumes.UploadImageOpts{
 			ImageName:  imageName,
 			DiskFormat: "raw",
 		}).Extract()
 		if err != nil {
-			return fmt.Errorf("error while uploading volume image: %v", err)
+			return fmt.Errorf("error while uploading image: %w", err)
 		}
 
 		// wait for image to be ready
+		isImageActive := false
 		for i := 0; i < c.options.UploadImageRetryCount; i++ {
-			imgObj, err := images.Get(c.ctx, c.imageClient, volImage.ImageID).Extract()
+			imgObj, err := images.Get(c.ctx, c.imageClient, volumeImage.ImageID).Extract()
 			if err != nil {
-				return fmt.Errorf("error checking status of volume image %s: %v", volImage.ImageID, err)
+				logrus.WithFields(logrus.Fields{
+					"name":                    vm.Name,
+					"namespace":               vm.Namespace,
+					"spec.virtualMachineName": vm.Spec.VirtualMachineName,
+					"image.id":                volumeImage.ImageID,
+				}).Errorf("Failed to get image: %v", err)
+			} else {
+				if imgObj.Status == images.ImageStatusActive {
+					isImageActive = true
+					break
+				}
 			}
-			if imgObj.Status == "active" {
-				break
-			}
+
 			logrus.WithFields(logrus.Fields{
 				"name":                    vm.Name,
 				"namespace":               vm.Namespace,
 				"spec.virtualMachineName": vm.Spec.VirtualMachineName,
 				"image.id":                imgObj.ID,
 				"image.status":            imgObj.Status,
-			}).Info("Waiting for raw image to be available")
+				"retryCount":              c.options.UploadImageRetryCount,
+				"retryDelay":              c.options.UploadImageRetryDelay,
+				"retryIndex":              i,
+			}).Infof("Waiting for image status to be '%s'", images.ImageStatusActive)
+
 			time.Sleep(time.Duration(c.options.UploadImageRetryDelay) * time.Second)
 		}
+		if !isImageActive {
+			return fmt.Errorf("timeout waiting for status '%s' of image %s", images.ImageStatusActive, volumeImage.ImageID)
+		}
 
 		logrus.WithFields(logrus.Fields{
 			"name":                    vm.Name,
 			"namespace":               vm.Namespace,
 			"spec.virtualMachineName": vm.Spec.VirtualMachineName,
-			"spec.sourceCluster.name": vm.Spec.SourceCluster.Name,
-			"spec.sourceCluster.kind": vm.Spec.SourceCluster.Kind,
-			"imageID":                 volImage.ImageID,
+			"imageID":                 volumeImage.ImageID,
 		}).Info("Downloading an image")
 
-		contents, err := imagedata.Download(c.ctx, c.imageClient, volImage.ImageID).Extract()
+		contents, err := imagedata.Download(c.ctx, c.imageClient, volumeImage.ImageID).Extract()
 		if err != nil {
-			return fmt.Errorf("error downloading volume image %s: %v", volImage.ImageID, err)
+			return fmt.Errorf("error downloading image %s: %w", volumeImage.ImageID, err)
 		}
 
-		rawImageFileName := generateRawImageFileName(vm.Status.ImportedVirtualMachineName, vIndex)
+		rawImageFileName := generateRawImageFileName(vm.Status.ImportedVirtualMachineName, index)
 
 		logrus.WithFields(logrus.Fields{
 			"name":                    vm.Name,
 			"namespace":               vm.Namespace,
 			"spec.virtualMachineName": vm.Spec.VirtualMachineName,
-			"volume.imageID":          volImage.ImageID,
+			"volume.imageID":          volumeImage.ImageID,
 			"rawImageFileName":        rawImageFileName,
 		}).Info("Downloading RAW image")
+
 		err = writeRawImageFile(filepath.Join(server.TempDir(), rawImageFileName), contents)
 		if err != nil {
-			return fmt.Errorf("error downloading RAW image %s: %v", rawImageFileName, err)
-		}
-
-		if err := volumes.Delete(c.ctx, c.storageClient, volObj.ID, volumes.DeleteOpts{}).ExtractErr(); err != nil {
-			return fmt.Errorf("error deleting volume %s: %v", volObj.ID, err)
-		}
-
-		if err := snapshots.Delete(c.ctx, c.storageClient, snapInfo.ID).ExtractErr(); err != nil {
-			return fmt.Errorf("error deleting snapshot %s: %v", snapInfo.ID, err)
-		}
-
-		if err := images.Delete(c.ctx, c.imageClient, volImage.ImageID).ExtractErr(); err != nil {
-			return fmt.Errorf("error deleting image %s: %v", volImage.ImageID, err)
+			return fmt.Errorf("error downloading RAW image %s: %w", rawImageFileName, err)
 		}
 
 		vm.Status.DiskImportStatus = append(vm.Status.DiskImportStatus, migration.DiskInfo{
 			Name:          rawImageFileName,
-			DiskSize:      int64(volObj.Size),
+			DiskSize:      int64(volume.Size),
 			DiskLocalPath: server.TempDir(),
 			BusType:       kubevirt.DiskBusVirtio,
 		})
+
+		return nil
+	}
+
+	for index, av := range vmObj.AttachedVolumes {
+		err := exportFn(index, av)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**Problem:**
The VM Import Controller only cleans up the snapshots , volumes and images created in OpenStack if the import is successful, which, in case of failure during any step before, would result in the resources not being cleaned up.

**Solution:**
Make sure all resources created during the export on the OpenStack side are correctly cleaned up, even in the event of a fault.

Additionally add missing check if volume image has become active during the configured retry time.

**Related Issue:**
https://github.com/harvester/harvester/issues/6676

**Test plan:**

***Test Case 1***
- Import a VM from OpenStack.
- If it has been successfully imported, go to the OpenStack UI (http://xxx/dashboard/project/snapshots/) and make sure there is no shadow copy.
```
time="2025-05-13T11:06:08Z" level=info msg="Exporting source VM" name=cirros-tiny namespace=default spec.sourceCluster.kind=OpenstackSource spec.sourceCluster.name=devstack spec.virtualMachineName=cirros-tiny status.importedVirtualMachineName=cirros-tiny
time="2025-05-13T11:06:09Z" level=info msg="Creating a new snapshot" name=cirros-tiny namespace=default opts.name=import-controller-cirros-tiny-0 opts.volumeid=e6565b2e-6f99-45e8-9278-fd4b4b35a1ea spec.virtualMachineName=cirros-tiny
time="2025-05-13T11:06:09Z" level=info msg="Waiting for snapshot to be available" name=cirros-tiny namespace=default snapshot.id=0d43aab7-9684-4ea8-b7a6-90057aff24e9 snapshot.name=import-controller-cirros-tiny-0 snapshot.size=1 snapshot.volumeid=e6565b2e-6f99-45e8-9278-fd4b4b35a1ea spec.virtualMachineName=cirros-tiny
time="2025-05-13T11:06:12Z" level=info msg="Waiting for volume to be available" name=cirros-tiny namespace=default retryCount=30 retryDelay=10 spec.virtualMachineName=cirros-tiny volume.createdAt="2025-05-13 11:06:12.127025 +0000 UTC" volume.id=3d39e32e-a65f-479d-9ed5-c34f5937fd1c volume.size=1 volume.snapshotID=0d43aab7-9684-4ea8-b7a6-90057aff24e9 volume.status=creating
time="2025-05-13T11:06:16Z" level=info msg="Creating a new image from a volume" name=cirros-tiny namespace=default opts.imagename=import-controller-cirros-tiny-0 spec.virtualMachineName=cirros-tiny volume.id=3d39e32e-a65f-479d-9ed5-c34f5937fd1c
time="2025-05-13T11:06:17Z" level=info msg="Waiting for image to be available" image.id=2d771149-8377-48c5-9e8f-f4ae0f94764f image.status=queued name=cirros-tiny namespace=default retryCount=30 retryDelay=10 retryIndex=0 spec.virtualMachineName=cirros-tiny
time="2025-05-13T11:06:28Z" level=info msg="Downloading an image" imageID=2d771149-8377-48c5-9e8f-f4ae0f94764f name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2025-05-13T11:06:28Z" level=info msg="Downloading RAW image" name=cirros-tiny namespace=default rawImageFileName=cirros-tiny-0.img spec.virtualMachineName=cirros-tiny volume.imageID=2d771149-8377-48c5-9e8f-f4ae0f94764f
```

- Look for `Waiting for snapshot to be available` to get the snapshot ID (here `e6565b2e-6f99-45e8-9278-fd4b4b35a1ea`).
- Look for `Waiting for volume to be available` to get the volume ID (here `32d07abe-f10b-4fc4-a136-60e6b7798cde`).

In the OpenStack UI they should be disappeared after the import.

![Bildschirmfoto vom 2025-05-13 13-42-46](https://github.com/user-attachments/assets/5a941489-92df-4df4-90c7-c77eb6da68da)

![Bildschirmfoto vom 2025-05-13 13-43-04](https://github.com/user-attachments/assets/dc641c50-3f7d-4814-a914-a0b27dc79912)

![grafik](https://github.com/user-attachments/assets/254a4779-32c0-45de-b886-381f237de243)

***Test Case 2***
- Import a VM from OpenStack.
- Check the logs live and when the message `Downloading an image` or `Downloading RAW image` appears, then make sure to drop the connection to the OpenStack server, e.g. by disabling the VPN connection. After some time the network calls should time out and the following error messages should appear in the log.
```
time="2025-05-13T11:55:16Z" level=info msg="Exporting source VM" name=cirros-tiny namespace=default spec.sourceCluster.kind=OpenstackSource spec.sourceCluster.name=devstack spec.virtualMachineName=cirros-tiny status.importedVirtualMachineName=cirros-tiny
time="2025-05-13T11:55:17Z" level=info msg="Creating a new snapshot" name=cirros-tiny namespace=default opts.name=import-controller-cirros-tiny-0 opts.volumeid=e6565b2e-6f99-45e8-9278-fd4b4b35a1ea spec.virtualMachineName=cirros-tiny
time="2025-05-13T11:55:18Z" level=info msg="Waiting for snapshot to be available" name=cirros-tiny namespace=default snapshot.id=0da8d67a-631d-4a61-857f-d8320fae3575 snapshot.name=import-controller-cirros-tiny-0 snapshot.size=1 snapshot.volumeid=e6565b2e-6f99-45e8-9278-fd4b4b35a1ea spec.virtualMachineName=cirros-tiny
time="2025-05-13T11:55:20Z" level=info msg="Waiting for volume to be available" name=cirros-tiny namespace=default retryCount=30 retryDelay=10 spec.virtualMachineName=cirros-tiny volume.createdAt="2025-05-13 11:55:20.502005 +0000 UTC" volume.id=9c6b2cfc-2f91-44f9-b32e-880b9c05bb7a volume.size=1 volume.snapshotID=0da8d67a-631d-4a61-857f-d8320fae3575 volume.status=creating
time="2025-05-13T11:55:24Z" level=info msg="Creating a new image from a volume" name=cirros-tiny namespace=default opts.imagename=import-controller-cirros-tiny-0 spec.virtualMachineName=cirros-tiny volume.id=9c6b2cfc-2f91-44f9-b32e-880b9c05bb7a
time="2025-05-13T11:55:25Z" level=info msg="Waiting for image to be available" image.id=a5b764b7-8562-4deb-8299-a6c29f9e3e6f image.status=queued name=cirros-tiny namespace=default retryCount=30 retryDelay=10 retryIndex=0 spec.virtualMachineName=cirros-tiny
time="2025-05-13T11:55:36Z" level=info msg="Downloading an image" imageID=a5b764b7-8562-4deb-8299-a6c29f9e3e6f name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2025-05-13T11:55:36Z" level=info msg="Downloading RAW image" name=cirros-tiny namespace=default rawImageFileName=cirros-tiny-0.img spec.virtualMachineName=cirros-tiny volume.imageID=a5b764b7-8562-4deb-8299-a6c29f9e3e6f
time="2025-05-13T12:00:38Z" level=error msg="Failed to delete image: Delete \"http://x.x.x.x/image/v2/images/a5b764b7-8562-4deb-8299-a6c29f9e3e6f\": dial tcp x.x.x.x:80: connect: connection timed out" image.id=a5b764b7-8562-4deb-8299-a6c29f9e3e6f name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
time="2025-05-13T12:02:49Z" level=error msg="Failed to delete volume: Delete \"http://x.x.x.x/volume/v3/88c800f12d7d4e4e93b2e2883aed1bf5/volumes/9c6b2cfc-2f91-44f9-b32e-880b9c05bb7a\": dial tcp x.x.x.x:80: connect: connection timed out" name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny volume.id=9c6b2cfc-2f91-44f9-b32e-880b9c05bb7a
time="2025-05-13T12:05:00Z" level=error msg="Failed to delete snapshot: Delete \"http://x.x.x.x/volume/v3/88c800f12d7d4e4e93b2e2883aed1bf5/snapshots/0da8d67a-631d-4a61-857f-d8320fae3575\": dial tcp x.x.x.x:80: connect: connection timed out" name=cirros-tiny namespace=default snapshot.id=0da8d67a-631d-4a61-857f-d8320fae3575 snapshot.name=import-controller-cirros-tiny-0 snapshot.volumeid=e6565b2e-6f99-45e8-9278-fd4b4b35a1ea spec.virtualMachineName=cirros-tiny
time="2025-05-13T12:05:00Z" level=error msg="Failed to export source VM: error downloading RAW image cirros-tiny-0.img: read tcp x.x.x.x:yyyyyy->x.x.x.x:80: read: connection timed out" name=cirros-tiny namespace=default spec.sourceCluster.kind=OpenstackSource spec.sourceCluster.name=devstack spec.virtualMachineName=cirros-tiny status.importedVirtualMachineName=cirros-tiny
time="2025-05-13T12:05:00Z" level=error msg="The VM import has failed" name=cirros-tiny namespace=default spec.virtualMachineName=cirros-tiny
```
The log messages `Failed to delete image`, `Failed to delete volume` and `Failed to delete snapshot` show that the resources are (tried) to be deleted on the OpenStack side.