### PR TITLE
chore: Configure Mergify to open backport PRs by labels [skip ci]

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -21,3 +21,36 @@ pull_request_rules:
   actions:
     comment:
       message: This pull request is now in conflict. Could you fix it @{{author}}? 🙏
+
+- name: Automatically open v1.6 backport PR
+  conditions:
+    - base=master
+    - label="pr-backport-to/v1.6"
+  actions:
+    backport:
+      branches:
+        - v1.6
+      assignees:
+        - "{{ author }}"
+
+- name: Automatically open v1.5 backport PR
+  conditions:
+    - base=master
+    - label="pr-backport-to/v1.5"
+  actions:
+    backport:
+      branches:
+        - v1.5
+      assignees:
+        - "{{ author }}"
+
+- name: Automatically open v1.4 backport PR
+  conditions:
+    - base=master
+    - label="pr-backport-to/v1.4"
+  actions:
+    backport:
+      branches:
+        - v1.4
+      assignees:
+        - "{{ author }}"


### PR DESCRIPTION
Use Mergify to automatically create backport PRs according to `backport-to/<branch>` labels.

Inspired by: https://github.com/harvester/harvester-installer/pull/833
