### PR TITLE
Existing status conditions are not updated

### DIFF
--- a/pkg/util/conditions.go
+++ b/pkg/util/conditions.go
@@ -28,8 +28,10 @@ func ConditionExists(conditions []common.Condition, c condition.Cond, condType c
 }
 
 func AddOrUpdateCondition(conditions []common.Condition, newCond common.Condition) []common.Condition {
-	var found bool
-	for _, v := range conditions {
+	found := false
+
+	for i := range conditions {
+		v := &conditions[i]
 		if v.Type == newCond.Type {
 			found = true
 			v.Status = newCond.Status

--- a/pkg/util/conditions_test.go
+++ b/pkg/util/conditions_test.go
@@ -146,3 +146,38 @@ func Test_RemoveCondition(t *testing.T) {
 	removeCond := RemoveCondition(conditions, migration.ClusterErrorCondition, corev1.ConditionFalse)
 	assert.False(ConditionExists(removeCond, migration.ClusterErrorCondition, corev1.ConditionFalse))
 }
+
+func Test_UpdateCondition(t *testing.T) {
+	conditions := []common.Condition{
+		{
+			Type:               migration.ClusterErrorCondition,
+			Status:             corev1.ConditionFalse,
+			LastUpdateTime:     metav1.Now().Format(time.RFC3339),
+			LastTransitionTime: metav1.Now().Format(time.RFC3339),
+		},
+		{
+			Type:               migration.ClusterReadyCondition,
+			Status:             corev1.ConditionFalse,
+			LastUpdateTime:     metav1.Now().Format(time.RFC3339),
+			LastTransitionTime: metav1.Now().Format(time.RFC3339),
+			Message:            "foo",
+		},
+	}
+
+	currentTime := metav1.Now().Format(time.RFC3339)
+	AddOrUpdateCondition(conditions, common.Condition{
+		Type:               migration.ClusterReadyCondition,
+		Status:             corev1.ConditionTrue,
+		LastUpdateTime:     currentTime,
+		LastTransitionTime: currentTime,
+		Message:            "bar",
+	})
+
+	assert := require.New(t)
+	assert.Len(conditions, 2)
+	assert.Equal(conditions[1].Type, migration.ClusterReadyCondition)
+	assert.Equal(conditions[1].Status, corev1.ConditionTrue)
+	assert.Equal(conditions[1].LastUpdateTime, currentTime)
+	assert.Equal(conditions[1].LastTransitionTime, currentTime)
+	assert.Equal(conditions[1].Message, "bar")
+}


### PR DESCRIPTION
**Problem:**
The helper function which is responsible for updating the status.conditions of the VM import source does not update existing conditions correctly because within the range iteration it is using the copy of the condition instead of the reference => therefore the condition is never updated on the resource.

**Solution:**
Fix the helper function.

**Related Issue:**
https://github.com/harvester/harvester/issues/9035

**Test plan:**
n/a
