### PR TITLE
Check in preflight-checks if VMware tools are running

### DIFF
--- a/pkg/controllers/migration/helper.go
+++ b/pkg/controllers/migration/helper.go
@@ -110,8 +110,9 @@ func (h *virtualMachineHandler) reconcilePreFlightChecks(vm *migration.VirtualMa
 		logrus.WithFields(logrus.Fields{
 			"name":                    vm.Name,
 			"namespace":               vm.Namespace,
+			"spec.sourcecluster.kind": vm.Spec.SourceCluster.Kind,
 			"spec.virtualMachineName": vm.Spec.VirtualMachineName,
-		}).Errorf("The preflight checks failed: %v", err)
+		}).Errorf("Failed to perform source cluster specific preflight checks: %v", err)
 		// Stop the reconciling for good as the checks failed.
 		vm.Status.Status = migration.VirtualMachineImportInvalid
 	} else {

--- a/pkg/controllers/migration/virtualmachine.go
+++ b/pkg/controllers/migration/virtualmachine.go
@@ -311,15 +311,10 @@ func (h *virtualMachineHandler) preFlightChecks(vm *migration.VirtualMachineImpo
 			"name":                    vm.Name,
 			"namespace":               vm.Namespace,
 			"spec.sourcecluster.kind": vm.Spec.SourceCluster.Kind,
-		}).Info("skipping preflight checks")
+		}).Info("Skipping preflight checks")
 	} else {
 		err = vmo.PreFlightChecks(vm)
 		if err != nil {
-			logrus.WithFields(logrus.Fields{
-				"name":                    vm.Name,
-				"namespace":               vm.Namespace,
-				"spec.sourcecluster.kind": vm.Spec.SourceCluster.Kind,
-			}).Errorf("Failed to perform source cluster specific preflight checks: %v", err)
 			return err
 		}
 	}

--- a/pkg/source/vmware/client.go
+++ b/pkg/source/vmware/client.go
@@ -147,8 +147,8 @@ func (c *Client) PreFlightChecks(vm *migration.VirtualMachineImport) (err error)
 		}).Info("Checking the source network as part of the preflight checks")
 
 		elements := strings.Split(nm.SourceNetwork, "/")
-		if _, ok := networkMap[elements[len(elements)-1]]; ok {
-			return nil
+		if _, ok := networkMap[elements[len(elements)-1]]; !ok {
+			return fmt.Errorf("source network '%s' not found", nm.SourceNetwork)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Volker Theile <vtheile@suse.com>**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
It must be ensured that the VMware Tools is running when a guest shutdown is requested, otherwise this attempt will fail and repeat endlessly.

**Solution:**
Add a check in the preflight-checks if VMware Tools is running.

**Related Issue:**
- https://github.com/harvester/harvester/issues/8903
- https://github.com/harvester/harvester/issues/9190

**Test plan:**
ToDo
