### PR TITLE
chore: bump golang 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.25.7 AS builder
+FROM registry.suse.com/bci/golang:1.26 AS builder
 
 ARG MK_HOST_ARCH
 ENV ARCH=$MK_HOST_ARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/vm-import-controller
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Changes:**

Bump golang 1.26 per internal audit.

**Related Issue:**

https://github.com/harvester/harvester/issues/10725

**Test plan:**

* Local `make ci package`, `go mod tidy`
* GH CI