### PR TITLE
Preserve source guest OS metadata during VM import

### DIFF
--- a/pkg/source/guestos.go
+++ b/pkg/source/guestos.go
@@ -1,0 +1,158 @@
+package source
+
+import "strings"
+
+// The OS values as offered by the Harvester UI's "OS Type" dropdown.
+const (
+	OsWindows    = "windows"
+	OsLinux      = "linux"
+	OsSLES       = "SLEs"
+	OsDebian     = "debian"
+	OsFedora     = "fedora"
+	OsGentoo     = "gentoo"
+	OsOracle     = "oracle"
+	OsRedHat     = "redhat"
+	OsOpenSUSE   = "openSUSE"
+	OsUbuntu     = "ubuntu"
+	OsOtherLinux = "otherLinux"
+	OsUnknown    = ""
+)
+
+// guestOsMapping maps a keyword to the OS value it identifies.
+type guestOsMapping struct {
+	match string
+	os    string
+}
+
+// guestOsIdPrefixes classifies structured/enumerated guest OS identifiers
+// by prefix, i.e. values chosen from a fixed, recognized vocabulary at VM
+// or image creation time, as opposed to arbitrary free text. Most of this
+// vocabulary originates from VMware's vim25/types.VirtualMachineGuestOsIdentifier
+// (see govmomi's vim25/types/enum.go), which names identifiers after the
+// distribution they represent, e.g. "ubuntu64Guest", "rhel9_64Guest",
+// "opensuse64Guest". The same vocabulary is reused by VMware-exported OVF
+// files (the OperatingSystemSection's "vmw:osType" attribute) and largely
+// overlaps with OpenStack Glance's standardized "os_distro" image property
+// (e.g. "ubuntu", "rhel", "rocky" - see
+// https://docs.openstack.org/glance/latest/admin/useful-image-properties.html),
+// whose recognized values are themselves prefixes of the VMware spelling.
+// A handful of entries (e.g. "gentoo", "arch", "sled") are recognized
+// "os_distro" values with no VMware guest OS identifier at all. They're
+// included here anyway, rather than only in guestOsNameKeywords below,
+// because "os_distro" is still a controlled vocabulary, not free text.
+// That's why this single table is shared between the vmware, ova and
+// openstack importers rather than duplicated per package.
+//
+// Plain string prefixes are used deliberately, instead of the typed
+// types.VirtualMachineGuestOsIdentifierXxx constants: VMware keeps naming new
+// releases after the same prefix (e.g. a future "debian14_64Guest"), so
+// prefix matching detects them automatically even with an older govmomi
+// version that doesn't define the constant yet. Matching against the
+// constants instead would leave every new identifier unrecognised until we
+// upgrade govmomi and add it here by hand.
+var guestOsIdPrefixes = []guestOsMapping{
+	{"opensuse", OsOpenSUSE},
+	{"sles", OsSLES},
+	{"sled", OsSLES},
+	{"suse", OsSLES},
+	{"debian", OsDebian},
+	{"fedora", OsFedora},
+	{"oraclelinux", OsOracle},
+	{"redhat", OsRedHat},
+	{"rhel", OsRedHat},
+	{"ubuntu", OsUbuntu},
+	{"centos", OsOtherLinux},
+	{"almalinux", OsLinux},
+	{"amazonlinux", OsLinux},
+	{"arch", OsLinux},
+	{"asianux", OsLinux},
+	{"coreos", OsLinux},
+	{"fusionos", OsLinux},
+	{"genericlinux", OsLinux},
+	{"gentoo", OsGentoo},
+	{"kylinlinux", OsLinux},
+	{"mandrake", OsLinux},
+	{"mandriva", OsLinux},
+	{"miraclelinux", OsLinux},
+	{"nld9", OsLinux},
+	{"oes", OsLinux},
+	{"pardus", OsLinux},
+	{"prolinux", OsLinux},
+	{"rocky", OsLinux},
+	{"turbolinux", OsLinux},
+	{"vmwarephoton", OsLinux},
+}
+
+// guestOsNameKeywords are a best-effort fallback over free text OS name
+// fields (e.g. VMware's GuestFullName/AlternateGuestName, or an OVF
+// OperatingSystemSection's Description), used when guestOsIdPrefixes yields
+// no match, e.g. for "otherGuest"/custom guest IDs, or for distros that have
+// no dedicated guest OS identifier at all, such as Gentoo. Unlike
+// guestOsIdPrefixes, "win" alone is not matched here: free text isn't bound
+// to VMware's fixed identifier vocabulary and "win" would false-positive on
+// e.g. "Darwin". The generic "linux" entry is kept last so more specific
+// distro keywords are tried first.
+var guestOsNameKeywords = []guestOsMapping{
+	{"windows", OsWindows},
+	{"gentoo", OsGentoo},
+	{"opensuse", OsOpenSUSE},
+	{"sles", OsSLES},
+	{"suse", OsSLES},
+	{"debian", OsDebian},
+	{"fedora", OsFedora},
+	{"oracle", OsOracle},
+	{"red hat", OsRedHat},
+	{"redhat", OsRedHat},
+	{"rhel", OsRedHat},
+	{"ubuntu", OsUbuntu},
+	{"centos", OsOtherLinux},
+	{"linux", OsLinux},
+}
+
+// GuestOsIdToOsType classifies a VMware guest OS identifier value (see
+// vim25/types.VirtualMachineGuestOsIdentifier) using guestOsIdPrefixes.
+// Every Windows identifier starts with "win" (e.g. "windows9_64Guest",
+// "winXPProGuest", "winNetStandardGuest" for Windows Server 2003), so that
+// case is handled directly.
+func GuestOsIdToOsType(id string) string {
+	id = strings.ToLower(strings.TrimSpace(id))
+	if id == "" {
+		return OsUnknown
+	}
+
+	if strings.HasPrefix(id, "win") {
+		return OsWindows
+	}
+
+	for _, prefix := range guestOsIdPrefixes {
+		if strings.HasPrefix(id, prefix.match) {
+			return prefix.os
+		}
+	}
+
+	// Covers other24xLinuxGuest, other3xLinux64Guest, ... otherLinuxGuest,
+	// otherLinux64Guest: some unspecified Linux flavor VMware couldn't name
+	// explicitly. This maps to the generic OsLinux value, not to Harvester's
+	// dedicated "Other Linux" entry.
+	if strings.HasPrefix(id, "other") && strings.Contains(id, "linux") {
+		return OsLinux
+	}
+
+	return OsUnknown
+}
+
+// GuestOsNameToOsType classifies a free text OS name using guestOsNameKeywords.
+func GuestOsNameToOsType(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return OsUnknown
+	}
+
+	for _, keyword := range guestOsNameKeywords {
+		if strings.Contains(name, keyword.match) {
+			return keyword.os
+		}
+	}
+
+	return OsUnknown
+}

--- a/pkg/source/guestos_test.go
+++ b/pkg/source/guestos_test.go
@@ -1,0 +1,77 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestGuestOsIdToOsType(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       string
+		expected string
+	}{
+		{name: "modern windows", id: string(types.VirtualMachineGuestOsIdentifierWindows11_64Guest), expected: OsWindows},
+		{name: "windows server 2003", id: string(types.VirtualMachineGuestOsIdentifierWinNetStandardGuest), expected: OsWindows},
+		{name: "windows xp", id: string(types.VirtualMachineGuestOsIdentifierWinXPProGuest), expected: OsWindows},
+		{name: "windows 98", id: string(types.VirtualMachineGuestOsIdentifierWin98Guest), expected: OsWindows},
+		{name: "sles", id: string(types.VirtualMachineGuestOsIdentifierSles15_64Guest), expected: OsSLES},
+		{name: "plain suse id also maps to sles", id: string(types.VirtualMachineGuestOsIdentifierSuse64Guest), expected: OsSLES},
+		{name: "opensuse", id: string(types.VirtualMachineGuestOsIdentifierOpensuse64Guest), expected: OsOpenSUSE},
+		{name: "debian", id: string(types.VirtualMachineGuestOsIdentifierDebian12_64Guest), expected: OsDebian},
+		{name: "fedora", id: string(types.VirtualMachineGuestOsIdentifierFedora64Guest), expected: OsFedora},
+		{name: "oracle linux", id: string(types.VirtualMachineGuestOsIdentifierOracleLinux8_64Guest), expected: OsOracle},
+		{name: "rhel", id: string(types.VirtualMachineGuestOsIdentifierRhel9_64Guest), expected: OsRedHat},
+		{name: "redhat", id: string(types.VirtualMachineGuestOsIdentifierRedhatGuest), expected: OsRedHat},
+		{name: "ubuntu", id: string(types.VirtualMachineGuestOsIdentifierUbuntu64Guest), expected: OsUbuntu},
+		{name: "centos maps to harvester otherLinux entry", id: string(types.VirtualMachineGuestOsIdentifierCentos7_64Guest), expected: OsOtherLinux},
+		{name: "generic linux family", id: string(types.VirtualMachineGuestOsIdentifierOther7xLinux64Guest), expected: OsLinux},
+		{name: "amazon linux", id: string(types.VirtualMachineGuestOsIdentifierAmazonlinux2_64Guest), expected: OsLinux},
+		{name: "rocky linux", id: string(types.VirtualMachineGuestOsIdentifierRockylinux_64Guest), expected: OsLinux},
+		{name: "bare rocky, e.g. openstack's os_distro value", id: "rocky", expected: OsLinux},
+		{name: "bare arch, e.g. openstack's os_distro value", id: "arch", expected: OsLinux},
+		{name: "bare sled, e.g. openstack's os_distro value", id: "sled", expected: OsSLES},
+		{name: "gentoo, e.g. openstack's os_distro value, has no vmware guest id equivalent", id: "gentoo", expected: OsGentoo},
+		{name: "darwin is not windows", id: string(types.VirtualMachineGuestOsIdentifierDarwin19_64Guest), expected: OsUnknown},
+		{name: "freebsd is unknown", id: string(types.VirtualMachineGuestOsIdentifierFreebsd64Guest), expected: OsUnknown},
+		{name: "unknown", id: string(types.VirtualMachineGuestOsIdentifierOtherGuest), expected: OsUnknown},
+		{name: "empty", id: "", expected: OsUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GuestOsIdToOsType(tt.id); got != tt.expected {
+				t.Fatalf("expected %q got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestGuestOsNameToOsType(t *testing.T) {
+	tests := []struct {
+		name      string
+		guestName string
+		expected  string
+	}{
+		{name: "windows", guestName: "Microsoft Windows Server 2019", expected: OsWindows},
+		{name: "gentoo has no vmware guest id, only detected via free text", guestName: "Gentoo", expected: OsGentoo},
+		{name: "sles free text", guestName: "SUSE Linux Enterprise Server 15", expected: OsSLES},
+		{name: "opensuse free text is not sles", guestName: "openSUSE Leap 15.5", expected: OsOpenSUSE},
+		{name: "red hat with a space", guestName: "Red Hat Enterprise Linux 8 (64-bit)", expected: OsRedHat},
+		{name: "centos free text maps to harvester otherLinux entry", guestName: "CentOS 7 (64-bit)", expected: OsOtherLinux},
+		{name: "generic linux distro fallback", guestName: "Ubuntu Linux (64-bit)", expected: OsUbuntu},
+		{name: "unclassified linux falls back to the generic entry", guestName: "Some Linux 5 (64-bit)", expected: OsLinux},
+		{name: "darwin free text is not windows", guestName: "Darwin 19.0", expected: OsUnknown},
+		{name: "unknown", guestName: "Other (32-bit)", expected: OsUnknown},
+		{name: "empty", guestName: "", expected: OsUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GuestOsNameToOsType(tt.guestName); got != tt.expected {
+				t.Fatalf("expected %q got %q", tt.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/source/helper.go
+++ b/pkg/source/helper.go
@@ -79,6 +79,7 @@ func NewVirtualMachineSpec(cfg VirtualMachineSpecConfig) *kubevirtv1.VirtualMach
 	}
 }
 
+// ApplyFirmwareSettings applies the firmware settings to the given VirtualMachineSpec custom resource.
 func ApplyFirmwareSettings(vmSpec *kubevirtv1.VirtualMachineSpec, fw *Firmware) {
 	if !fw.UEFI {
 		return
@@ -106,6 +107,17 @@ func ApplyFirmwareSettings(vmSpec *kubevirtv1.VirtualMachineSpec, fw *Firmware) 
 			Enabled: ptr.To(true),
 		}
 	}
+}
+
+// ApplyGuestOsLabel applies the guest OS label to the given VirtualMachine custom resource.
+func ApplyGuestOsLabel(vm *kubevirtv1.VirtualMachine, guestOsType string) {
+	if guestOsType == "" {
+		return
+	}
+	if vm.Labels == nil {
+		vm.Labels = make(map[string]string)
+	}
+	vm.Labels["harvesterhci.io/os"] = guestOsType
 }
 
 // RemoveTempImageFiles removes temporary image files used during migration.

--- a/pkg/source/openstack/client.go
+++ b/pkg/source/openstack/client.go
@@ -243,11 +243,12 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) error 
 		return err
 	}
 
+	// Log the origin VM specification for better troubleshooting.
 	logrus.WithFields(util.FieldsToJSON(logrus.Fields{
 		"name":      vm.Name,
 		"namespace": vm.Namespace,
-		"spec":      vmObj.AttachedVolumes,
-	}, []string{"spec"})).Info("Origin spec of the volumes to be imported")
+		"spec":      vmObj,
+	}, []string{"spec"})).Info("Origin spec of the VM to be imported")
 
 	// Helper function to do the export.
 	// This is necessary so that the defer functions are executed at the right
@@ -524,23 +525,18 @@ func (c *Client) GenerateVirtualMachine(vm *migration.VirtualMachineImport) (*ku
 		return nil, fmt.Errorf("error finding VM in GenerateVirtualMachine: %v", err)
 	}
 
-	// Log the origin VM specification for better troubleshooting.
-	// Note, JSON is used to be able to prettify the output for better readability.
-	logrus.WithFields(util.FieldsToJSON(logrus.Fields{
-		"name":      vm.Name,
-		"namespace": vm.Namespace,
-		"spec":      vmObj,
-	}, []string{"spec"})).Info("Origin spec of the VM to be imported")
-
 	flavorObj, err := flavors.Get(c.ctx, c.computeClient, vmObj.Flavor["id"].(string)).Extract()
 	if err != nil {
 		return nil, fmt.Errorf("error looking up flavor: %w", err)
 	}
 
-	fw, err := c.getFirmwareSettings(&vmObj.Server)
+	imageInfo, err := c.getBootImage(&vmObj.Server)
 	if err != nil {
-		return nil, fmt.Errorf("error getting firware settings: %w", err)
+		return nil, fmt.Errorf("error getting boot image: %w", err)
 	}
+
+	fw := getFirmwareSettings(imageInfo)
+	guestOsType := detectGuestOsType(imageInfo)
 
 	networkInfos, err := generateNetworkInfos(vmObj.Addresses, vm.GetDefaultNetworkInterfaceModel())
 	if err != nil {
@@ -579,6 +575,8 @@ func (c *Client) GenerateVirtualMachine(vm *migration.VirtualMachineImport) (*ku
 	vmSpec.Template.Spec.Networks = networkConfig
 	vmSpec.Template.Spec.Domain.Devices.Interfaces = interfaceConfig
 	newVM.Spec = *vmSpec
+
+	source.ApplyGuestOsLabel(newVM, guestOsType)
 
 	// disk attachment needs query by core controller for storage classes, so will be added by the migration controller
 	return newVM, nil
@@ -709,23 +707,35 @@ func (c *Client) findVM(name string) (*ExtendedServer, error) {
 	return &s, err
 }
 
-func (c *Client) getFirmwareSettings(instance *servers.Server) (*source.Firmware, error) {
+// getBootImage looks up the Glance image the instance was booted from, by
+// finding its bootable attached volume and resolving the image referenced in
+// that volume's image metadata. OpenStack exposes no firmware or guest OS
+// information on the instance itself - both are only available as
+// properties on the Glance image it was booted from.
+func (c *Client) getBootImage(instance *servers.Server) (*images.Image, error) {
 	var imageID string
 
 	for _, v := range instance.AttachedVolumes {
 		resp := volumes.Get(c.ctx, c.storageClient, v.ID)
 		var volInfo volumes.Volume
 		if err := resp.ExtractIntoStructPtr(&volInfo, "volume"); err != nil {
-			return nil, fmt.Errorf("error extracting volume info for volume %s: %v", v.ID, err)
+			return nil, fmt.Errorf("error extracting volume info for volume %s: %w", v.ID, err)
 		}
 
 		if volInfo.Bootable == "true" {
 			var volStatus ExtendedVolume
 			if err := resp.ExtractIntoStructPtr(&volStatus, "volume"); err != nil {
-				return nil, fmt.Errorf("error extracting volume status for volume %s: %v", v.ID, err)
+				return nil, fmt.Errorf("error extracting volume status for volume %s: %w", v.ID, err)
 			}
-			imageID = volStatus.VolumeImageMetadata["image_id"]
+			if value, ok := volStatus.VolumeImageMetadata["image_id"]; ok && value != "" {
+				imageID = value
+				break
+			}
 		}
+	}
+
+	if imageID == "" {
+		return nil, fmt.Errorf("no bootable volume with image metadata found for instance %s", instance.ID)
 	}
 
 	imageInfo, err := images.Get(c.ctx, c.imageClient, imageID).Extract()
@@ -733,13 +743,25 @@ func (c *Client) getFirmwareSettings(instance *servers.Server) (*source.Firmware
 		return nil, fmt.Errorf("error getting image details for image %s: %v", imageID, err)
 	}
 
+	return imageInfo, nil
+}
+
+// getFirmwareSettings extracts the BIOS/EFI, SecureBoot and TPM settings
+// from the given Glance image's properties: "hw_firmware_type" ("uefi"),
+// "hw_tpm_model", and "os_secure_boot" ("required" or "optional"). See
+// https://docs.openstack.org/glance/latest/admin/useful-image-properties.html
+// for more information.
+func getFirmwareSettings(imageInfo *images.Image) *source.Firmware {
 	fw := source.NewFirmware(false, false, false)
 
-	firmwareType, ok := imageInfo.Properties["hw_firmware_type"]
-	if ok && firmwareType.(string) == "uefi" {
+	if imageInfo == nil {
+		return fw
+	}
+
+	if firmwareType, ok := imageInfo.Properties["hw_firmware_type"]; ok && firmwareType == "uefi" {
 		fw.UEFI = true
 	}
-	logrus.Debugf("found image firmware settings %v", imageInfo.Properties)
+
 	if _, ok := imageInfo.Properties["hw_tpm_model"]; ok {
 		fw.TPM = true
 	}
@@ -748,7 +770,35 @@ func (c *Client) getFirmwareSettings(instance *servers.Server) (*source.Firmware
 		fw.SecureBoot = true
 	}
 
-	return fw, nil
+	return fw
+}
+
+// detectGuestOsType determines the guest OS type from a Glance image,
+// preferring the most specific source available:
+//  1. "os_distro": a recognized, standardized property value,
+//     e.g. "ubuntu", "rhel", "windows", "gentoo".
+//     See https://docs.openstack.org/glance/latest/admin/useful-image-properties.html
+//     for more information.
+//  2. "os_type": the coarse linux/windows family, used as a fallback when
+//     "os_distro" is absent or not a recognized value.
+func detectGuestOsType(imageInfo *images.Image) string {
+	if imageInfo == nil {
+		return source.OsUnknown
+	}
+
+	if osDistro, ok := imageInfo.Properties["os_distro"].(string); ok {
+		if osType := source.GuestOsIdToOsType(osDistro); osType != source.OsUnknown {
+			return osType
+		}
+	}
+
+	if osTypeProp, ok := imageInfo.Properties["os_type"].(string); ok {
+		if osType := source.GuestOsNameToOsType(osTypeProp); osType != source.OsUnknown {
+			return osType
+		}
+	}
+
+	return source.OsUnknown
 }
 
 func generateNetworkInfos(info map[string]interface{}, defaultInterfaceModel string) ([]source.NetworkInfo, error) {

--- a/pkg/source/openstack/client_test.go
+++ b/pkg/source/openstack/client_test.go
@@ -3,10 +3,15 @@ package openstack
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"os"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/v2/openstack/image/v2/images"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	thclient "github.com/gophercloud/gophercloud/v2/testhelper/client"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
@@ -14,59 +19,65 @@ import (
 
 	migration "github.com/harvester/vm-import-controller/pkg/apis/migration.harvesterhci.io/v1beta1"
 	"github.com/harvester/vm-import-controller/pkg/server"
+	"github.com/harvester/vm-import-controller/pkg/source"
 )
 
 var (
 	c *Client
 )
 
+// TestMain sets up a live OpenStack client for the tests that need one, but
+// only when USE_EXISTING_CLUSTER is set. Tests that require it call
+// requireExistingCluster to skip themselves individually when it isn't -
+// unlike bailing out of TestMain entirely, this still lets the many unit
+// tests in this package that don't touch a real OpenStack deployment run.
 func TestMain(t *testing.M) {
-	var err error
-
-	// skip tests, needed for current builds
-	_, ok := os.LookupEnv("USE_EXISTING_CLUSTER")
-	if !ok {
-		logrus.Warn("skipping tests")
-		return
-	}
-
-	s, err := SetupOpenstackSecretFromEnv("devstack")
-	if err != nil {
-		logrus.Fatal(err)
-	}
-	endpoint, region, err := SetupOpenstackSourceFromEnv()
-	if err != nil {
-		logrus.Fatal(err)
-	}
-
-	source := migration.OpenstackSource{}
-	options := source.GetOptions().(migration.OpenstackSourceOptions)
-
-	c, err = NewClient(context.TODO(), endpoint, region, s, options)
-	if err != nil {
-		logrus.Fatal(err)
-	}
-
-	go func() {
-		if err = server.NewServer(context.TODO()); err != nil {
-			logrus.Fatalf("error creating server: %v", err)
+	if _, ok := os.LookupEnv("USE_EXISTING_CLUSTER"); ok {
+		s, err := SetupOpenstackSecretFromEnv("devstack")
+		if err != nil {
+			logrus.Fatal(err)
 		}
-	}()
+		endpoint, region, err := SetupOpenstackSourceFromEnv()
+		if err != nil {
+			logrus.Fatal(err)
+		}
 
-	if err != nil {
-		logrus.Fatal(err)
+		obj := migration.OpenstackSource{}
+		options := obj.GetOptions().(migration.OpenstackSourceOptions)
+
+		c, err = NewClient(context.TODO(), endpoint, region, s, options)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		go func() {
+			if err := server.NewServer(context.TODO()); err != nil {
+				logrus.Fatalf("error creating server: %v", err)
+			}
+		}()
 	}
 
-	code := t.Run()
-	os.Exit(code)
+	os.Exit(t.Run())
 }
+
+// requireExistingCluster skips the calling test when no live OpenStack
+// cluster is available, i.e. when TestMain ran without USE_EXISTING_CLUSTER.
+func requireExistingCluster(t *testing.T) {
+	t.Helper()
+	if c == nil {
+		t.Skip("skipping test: requires USE_EXISTING_CLUSTER and a live OpenStack environment")
+	}
+}
+
 func Test_NewClient(t *testing.T) {
+	requireExistingCluster(t)
 	assert := require.New(t)
 	err := c.Verify()
 	assert.NoError(err, "expect no error during verify of client")
 }
 
 func Test_checkOrGetUUID(t *testing.T) {
+	requireExistingCluster(t)
 	assert := require.New(t)
 	vmName, ok := os.LookupEnv("OS_VM_NAME")
 	assert.True(ok, "expected env variable VM_NAME to be set")
@@ -75,6 +86,7 @@ func Test_checkOrGetUUID(t *testing.T) {
 }
 
 func Test_IsPoweredOff(t *testing.T) {
+	requireExistingCluster(t)
 	assert := require.New(t)
 	vmName, ok := os.LookupEnv("OS_VM_NAME")
 	assert.True(ok, "expected env variable VM_NAME to be set")
@@ -88,6 +100,7 @@ func Test_IsPoweredOff(t *testing.T) {
 }
 
 func Test_ShutdownGuest(t *testing.T) {
+	requireExistingCluster(t)
 	assert := require.New(t)
 	vmName, ok := os.LookupEnv("OS_VM_NAME")
 	assert.True(ok, "expected env variable VM_NAME to be set")
@@ -101,6 +114,7 @@ func Test_ShutdownGuest(t *testing.T) {
 }
 
 func Test_PowerOff(t *testing.T) {
+	requireExistingCluster(t)
 	assert := require.New(t)
 	vmName, ok := os.LookupEnv("OS_VM_NAME")
 	assert.True(ok, "expected env variable VM_NAME to be set")
@@ -115,12 +129,14 @@ func Test_PowerOff(t *testing.T) {
 }
 
 func Test_IsPowerOffSupported(t *testing.T) {
+	requireExistingCluster(t)
 	assert := require.New(t)
 	supported := c.IsPowerOffSupported()
 	assert.False(supported, "expected powering off is not supported")
 }
 
 func Test_ExportVirtualMachine(t *testing.T) {
+	requireExistingCluster(t)
 	assert := require.New(t)
 	vmName, ok := os.LookupEnv("OS_VM_NAME")
 	assert.True(ok, "expected env variable VM_NAME to be set")
@@ -136,6 +152,7 @@ func Test_ExportVirtualMachine(t *testing.T) {
 }
 
 func Test_GenerateVirtualMachine(t *testing.T) {
+	requireExistingCluster(t)
 	assert := require.New(t)
 	vmName := os.Getenv("OS_VM_NAME")
 	assert.NotEmpty(vmName, "expected env variable VM_NAME to be set")
@@ -169,7 +186,153 @@ func Test_generateNetworkInfo(t *testing.T) {
 	assert.Equal(vmInterfaceDetails[1].Model, migration.NetworkInterfaceModelVirtio, "expected to have a NIC with virtio model")
 }
 
+func Test_getFirmwareSettings(t *testing.T) {
+	assert := require.New(t)
+
+	t.Run("nil image", func(t *testing.T) {
+		fw := getFirmwareSettings(nil)
+		assert.Equal(source.NewFirmware(false, false, false), fw)
+	})
+
+	t.Run("hw_firmware_type is not a string", func(t *testing.T) {
+		fw := getFirmwareSettings(&images.Image{
+			Properties: map[string]any{"hw_firmware_type": true},
+		})
+		assert.False(fw.UEFI, "expected UEFI to stay false when hw_firmware_type has an unexpected type")
+	})
+
+	t.Run("recognized properties", func(t *testing.T) {
+		fw := getFirmwareSettings(&images.Image{
+			Properties: map[string]any{
+				"hw_firmware_type": "uefi",
+				"hw_tpm_model":     "tpm-version-2.0",
+				"os_secure_boot":   "required",
+			},
+		})
+		assert.True(fw.UEFI)
+		assert.True(fw.TPM)
+		assert.True(fw.SecureBoot)
+	})
+}
+
+func Test_detectGuestOsType(t *testing.T) {
+	tests := []struct {
+		name      string
+		imageInfo *images.Image
+		expected  string
+	}{
+		{
+			name:      "no properties",
+			imageInfo: &images.Image{},
+			expected:  source.OsUnknown,
+		},
+		{
+			name: "recognized os_distro value",
+			imageInfo: &images.Image{
+				Properties: map[string]any{"os_distro": "ubuntu"},
+			},
+			expected: source.OsUbuntu,
+		},
+		{
+			name: "os_distro value recognized by openstack with no vmware guest id equivalent",
+			imageInfo: &images.Image{
+				Properties: map[string]any{"os_distro": "gentoo"},
+			},
+			expected: source.OsGentoo,
+		},
+		{
+			name: "os_type fallback when os_distro is absent",
+			imageInfo: &images.Image{
+				Properties: map[string]any{"os_type": "windows"},
+			},
+			expected: source.OsWindows,
+		},
+		{
+			name: "os_type fallback when os_distro is unrecognized",
+			imageInfo: &images.Image{
+				Properties: map[string]any{"os_distro": "my-custom-os", "os_type": "linux"},
+			},
+			expected: source.OsLinux,
+		},
+		{
+			name: "unrecognized os_distro and no os_type",
+			imageInfo: &images.Image{
+				Properties: map[string]any{"os_distro": "my-custom-os"},
+			},
+			expected: source.OsUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectGuestOsType(tt.imageInfo); got != tt.expected {
+				t.Fatalf("expected %q got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func Test_getBootImage(t *testing.T) {
+	assert := require.New(t)
+
+	t.Run("instance without any attached volumes", func(t *testing.T) {
+		client := &Client{ctx: context.Background()}
+		instance := &servers.Server{ID: "server-1"}
+
+		imageInfo, err := client.getBootImage(instance)
+		assert.Nil(imageInfo)
+		assert.ErrorContains(err, "no bootable volume with image metadata found for instance server-1")
+	})
+
+	t.Run("attached volume is not bootable", func(t *testing.T) {
+		fakeServer := th.SetupHTTP()
+		defer fakeServer.Teardown()
+
+		fakeServer.Mux.HandleFunc("/volumes/vol-1", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"volume": {"id": "vol-1", "bootable": "false"}}`)
+		})
+
+		client := &Client{
+			ctx:           context.Background(),
+			storageClient: thclient.ServiceClient(fakeServer),
+		}
+		instance := &servers.Server{ID: "server-1", AttachedVolumes: []servers.AttachedVolume{{ID: "vol-1"}}}
+
+		imageInfo, err := client.getBootImage(instance)
+		assert.Nil(imageInfo)
+		assert.ErrorContains(err, "no bootable volume with image metadata found for instance server-1")
+	})
+
+	t.Run("bootable volume resolves the boot image", func(t *testing.T) {
+		fakeServer := th.SetupHTTP()
+		defer fakeServer.Teardown()
+
+		fakeServer.Mux.HandleFunc("/volumes/vol-1", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"volume": {"id": "vol-1", "bootable": "true", "volume_image_metadata": {"image_id": "image-1"}}}`)
+		})
+		fakeServer.Mux.HandleFunc("/images/image-1", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"id": "image-1", "name": "test-image", "os_distro": "ubuntu"}`)
+		})
+
+		client := &Client{
+			ctx:           context.Background(),
+			storageClient: thclient.ServiceClient(fakeServer),
+			imageClient:   thclient.ServiceClient(fakeServer),
+		}
+		instance := &servers.Server{ID: "server-1", AttachedVolumes: []servers.AttachedVolume{{ID: "vol-1"}}}
+
+		imageInfo, err := client.getBootImage(instance)
+		assert.NoError(err)
+		assert.Equal("image-1", imageInfo.ID)
+		assert.Equal("ubuntu", imageInfo.Properties["os_distro"])
+	})
+}
+
 func Test_ClientOptions(t *testing.T) {
+	requireExistingCluster(t)
 	assert := require.New(t)
 	assert.Equal(c.options.UploadImageRetryCount, migration.OpenstackDefaultRetryCount)
 	assert.Equal(c.options.UploadImageRetryDelay, migration.OpenstackDefaultRetryDelay)
@@ -216,12 +379,12 @@ func Test_SourceGetOptions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		source := migration.OpenstackSource{
+		obj := migration.OpenstackSource{
 			Spec: migration.OpenstackSourceSpec{
 				OpenstackSourceOptions: tc.options,
 			},
 		}
-		options := source.GetOptions().(migration.OpenstackSourceOptions)
+		options := obj.GetOptions().(migration.OpenstackSourceOptions)
 
 		assert.Equal(options.UploadImageRetryCount, tc.expected.UploadImageRetryCount, tc.desc)
 		assert.Equal(options.UploadImageRetryDelay, tc.expected.UploadImageRetryDelay, tc.desc)
@@ -246,6 +409,6 @@ func Test_ExtendedServer(t *testing.T) {
 
 	assert.NoError(err, "expect no error during extract")
 	assert.Equal(s.Name, "cirros-tiny", "expect name to be 'cirros-tiny'")
-	assert.Equal(s.Status, "", "expect status to be 'SHUTOFF'")
+	assert.Equal(s.Status, "SHUTOFF", "expect status to be 'SHUTOFF'")
 	assert.Equal(s.Description, "test foo bar", "expect description to be 'test foo bar'")
 }

--- a/pkg/source/ova/client.go
+++ b/pkg/source/ova/client.go
@@ -144,7 +144,7 @@ func (c *Client) ExportVirtualMachine(vmi *migration.VirtualMachineImport) error
 		return fmt.Errorf("failed to read envelope: %w", err)
 	}
 
-	_, _, _, dis := parseEnvelope(e, vmi.GetDefaultNetworkInterfaceModel(), vmi.GetDefaultDiskBusType())
+	_, _, _, dis, _ := parseEnvelope(e, vmi.GetDefaultNetworkInterfaceModel(), vmi.GetDefaultDiskBusType())
 	logrus.WithFields(util.FieldsToJSON(logrus.Fields{
 		"name":      vmi.Name,
 		"namespace": vmi.Namespace,
@@ -178,7 +178,7 @@ func (c *Client) GenerateVirtualMachine(vmi *migration.VirtualMachineImport) (*k
 		return nil, fmt.Errorf("failed to read envelope: %w", err)
 	}
 
-	fw, hw, nis, dis := parseEnvelope(e, vmi.GetDefaultNetworkInterfaceModel(), vmi.GetDefaultDiskBusType())
+	fw, hw, nis, dis, got := parseEnvelope(e, vmi.GetDefaultNetworkInterfaceModel(), vmi.GetDefaultDiskBusType())
 	logrus.WithFields(util.FieldsToJSON(logrus.Fields{
 		"name":         vmi.Name,
 		"namespace":    vmi.Namespace,
@@ -186,6 +186,7 @@ func (c *Client) GenerateVirtualMachine(vmi *migration.VirtualMachineImport) (*k
 		"hardware":     hw,
 		"networkInfos": nis,
 		"diskInfos":    dis,
+		"guestOsType":  got,
 	}, []string{"firmware", "hardware", "networkInfos", "diskInfos"})).Info("Parsed configuration from OVF envelope")
 
 	newVM := &kubevirtv1.VirtualMachine{
@@ -213,6 +214,8 @@ func (c *Client) GenerateVirtualMachine(vmi *migration.VirtualMachineImport) (*k
 	vmSpec.Template.Spec.Networks = networkConfig
 	vmSpec.Template.Spec.Domain.Devices.Interfaces = interfaceConfig
 	newVM.Spec = *vmSpec
+
+	source.ApplyGuestOsLabel(newVM, got)
 
 	return newVM, nil
 }
@@ -558,15 +561,57 @@ func detectDiskBusType(rasd *ovf.ResourceAllocationSettingData) (kubevirtv1.Disk
 	return busType, busType != ""
 }
 
-// parseEnvelope retrieves the firmware, virtual hardware and network settings from the OVF envelope.
-func parseEnvelope(e *ovf.Envelope, defaultInterfaceModel string, defaultDiskBusType kubevirtv1.DiskBus) (*source.Firmware, *source.Hardware, []source.NetworkInfo, []migration.DiskInfo) {
+// detectGuestOsType determines the guest OS type from an OVF VirtualSystem,
+// preferring the most specific source available:
+//  1. OperatingSystemSection.OSType: for OVAs exported by VMware, this is set
+//     to the same guest OS identifier vocabulary used by the vSphere API
+//     (see vim25/types.VirtualMachineGuestOsIdentifier), e.g. "ubuntu64Guest".
+//  2. OperatingSystemSection.Description: free text (e.g. "Ubuntu Linux
+//     (64-bit)"), used as a fallback for OVAs from other exporters that
+//     don't set OSType (e.g. VirtualBox).
+//  3. ProductSection.Product: free text naming the packaged product (e.g.
+//     "Windows"), used as a last resort when OperatingSystemSection is
+//     absent or carries no usable information at all.
+func detectGuestOsType(vs *ovf.VirtualSystem) string {
+	if vs == nil {
+		return source.OsUnknown
+	}
+
+	if oss := vs.OperatingSystem; oss != nil {
+		if oss.OSType != nil {
+			if osType := source.GuestOsIdToOsType(*oss.OSType); osType != source.OsUnknown {
+				return osType
+			}
+		}
+		if oss.Description != nil {
+			if osType := source.GuestOsNameToOsType(*oss.Description); osType != source.OsUnknown {
+				return osType
+			}
+		}
+	}
+
+	for _, product := range vs.Product {
+		if osType := source.GuestOsNameToOsType(product.Product); osType != source.OsUnknown {
+			return osType
+		}
+	}
+
+	return source.OsUnknown
+}
+
+// parseEnvelope retrieves the firmware, virtual hardware, network settings
+// and guest OS from the OVF envelope.
+func parseEnvelope(e *ovf.Envelope, defaultInterfaceModel string, defaultDiskBusType kubevirtv1.DiskBus) (*source.Firmware, *source.Hardware, []source.NetworkInfo, []migration.DiskInfo, string) {
 	fw := source.NewFirmware(false, false, false)
 	hw := source.NewHardware(0, 0, 0)
 	nis := make([]source.NetworkInfo, 0)
 	dis := make([]migration.DiskInfo, 0)
+	got := source.OsUnknown
 
 	if e.VirtualSystem != nil {
 		disks := ptr.Deref(e.Disk, ovf.DiskSection{Disks: []ovf.VirtualDiskDesc{}}).Disks
+
+		got = detectGuestOsType(e.VirtualSystem)
 
 		for _, vh := range e.VirtualSystem.VirtualHardware {
 			// OVF v1.0 - <Item>
@@ -701,7 +746,7 @@ func parseEnvelope(e *ovf.Envelope, defaultInterfaceModel string, defaultDiskBus
 		}
 	}
 
-	return fw, hw, nis, dis
+	return fw, hw, nis, dis, got
 }
 
 // newHttpRequest creates a new HTTP request with optional basic authentication.

--- a/pkg/source/ova/client_test.go
+++ b/pkg/source/ova/client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware/govmomi/ovf"
 	"github.com/vmware/govmomi/ovf/importer"
 	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -287,6 +288,139 @@ var ovfData3 = `<?xml version="1.0"?>
   </VirtualSystem>
 </Envelope>`
 
+// See https://github.com/brimstone/windows-ova/blob/master/Windows.ovf
+var ovfData4 = `<?xml version="1.0" encoding="UTF-8"?>
+<Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:cim="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:vbox="http://www.virtualbox.org/ovf/machine">
+  <References>
+    <File ovf:href="Windows-c.vmdk" ovf:id="file1" ovf:size="107374182400" />
+    <File ovf:href="Windows-d.vmdk" ovf:id="file2" ovf:size="10737418240" />
+  </References>
+  <DiskSection>
+    <Info>List of the virtual disks used in the package</Info>
+    <Disk ovf:capacity="107374182400" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" vbox:uuid="1bcd998b-a8ab-4b31-a6bb-ea958070ceb3" />
+    <Disk ovf:capacity="10737418240" ovf:diskId="vmdisk2" ovf:fileRef="file2" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" vbox:uuid="3910cbf3-f47d-4cdc-887e-dcf4587e36a3" />
+  </DiskSection>
+  <NetworkSection>
+    <Info>Logical networks used in the package</Info>
+    <Network ovf:name="NAT">
+      <Description>Logical network used by this appliance.</Description>
+    </Network>
+  </NetworkSection>
+  <VirtualSystem ovf:id="Windows">
+    <Info>A virtual machine</Info>
+    <ProductSection>
+      <Info>Meta-information about the installed software</Info>
+      <Product>Windows</Product>
+      <ProductUrl>https://github.com/brimstone/windows-ova</ProductUrl>
+      <Version>1.2.3</Version>
+    </ProductSection>
+    <AnnotationSection>
+      <Info>A human-readable annotation</Info>
+      <Annotation>Self-Installing Windows VM</Annotation>
+    </AnnotationSection>
+    <OperatingSystemSection ovf:id="102">
+      <Info>The kind of installed guest operating system</Info>
+      <Description>Other_64</Description>
+      <vbox:OSType ovf:required="false">WindowsNT_64</vbox:OSType>
+    </OperatingSystemSection>
+    <VirtualHardwareSection>
+      <Info>Virtual hardware requirements for a virtual machine</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemIdentifier>Windows</vssd:VirtualSystemIdentifier>
+        <vssd:VirtualSystemType>vmx-11</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:Caption>1 virtual CPU</rasd:Caption>
+        <rasd:Description>Number of virtual CPUs</rasd:Description>
+        <rasd:ElementName>1 virtual CPU</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>MegaBytes</rasd:AllocationUnits>
+        <rasd:Caption>1024 MB of memory</rasd:Caption>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>1024 MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>1024</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Caption>ideController0</rasd:Caption>
+        <rasd:Description>IDE Controller</rasd:Description>
+        <rasd:ElementName>ideController0</rasd:ElementName>
+        <rasd:InstanceID>3</rasd:InstanceID>
+        <rasd:ResourceSubType>PIIX4</rasd:ResourceSubType>
+        <rasd:ResourceType>5</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Caption>sataController0</rasd:Caption>
+        <rasd:Description>SATA Controller</rasd:Description>
+        <rasd:ElementName>sataController0</rasd:ElementName>
+        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:ResourceSubType>AHCI</rasd:ResourceSubType>
+        <rasd:ResourceType>20</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Caption>usb</rasd:Caption>
+        <rasd:Description>USB Controller</rasd:Description>
+        <rasd:ElementName>usb</rasd:ElementName>
+        <rasd:InstanceID>5</rasd:InstanceID>
+        <rasd:ResourceType>23</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:Caption>disk1</rasd:Caption>
+        <rasd:Description>Disk Image</rasd:Description>
+        <rasd:ElementName>disk1</rasd:ElementName>
+        <rasd:HostResource>/disk/vmdisk1</rasd:HostResource>
+        <rasd:InstanceID>6</rasd:InstanceID>
+        <rasd:Parent>4</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>1</rasd:AddressOnParent>
+        <rasd:Caption>disk2</rasd:Caption>
+        <rasd:Description>Disk Image</rasd:Description>
+        <rasd:ElementName>disk2</rasd:ElementName>
+        <rasd:HostResource>/disk/vmdisk2</rasd:HostResource>
+        <rasd:InstanceID>7</rasd:InstanceID>
+        <rasd:Parent>4</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Caption>cdrom0</rasd:Caption>
+        <rasd:Description>CD-ROM Drive</rasd:Description>
+        <rasd:ElementName>cdrom0</rasd:ElementName>
+        <rasd:HostResource></rasd:HostResource>
+        <!-- vmware rasd:HostResource>ovf:/file/file3</rasd:HostResource-->
+        <!-- virtualbox rasd:HostResource>ovf:/disk/vmdisk3</rasd:HostResource-->
+        <rasd:InstanceID>8</rasd:InstanceID>
+        <rasd:Parent>3</rasd:Parent>
+        <rasd:ResourceType>15</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>7</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Caption>Ethernet adapter on 'NAT'</rasd:Caption>
+        <rasd:Connection>NAT</rasd:Connection>
+        <rasd:ElementName>Ethernet adapter on 'NAT'</rasd:ElementName>
+        <rasd:InstanceID>9</rasd:InstanceID>
+        <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
+        <rasd:ResourceType>10</rasd:ResourceType>
+      </Item>
+    </VirtualHardwareSection>
+  </VirtualSystem>
+</Envelope>`
+
 func Test_NewClient(t *testing.T) {
 	assert := require.New(t)
 
@@ -554,30 +688,33 @@ func Test_extractAndConvertVMDKToRAW(t *testing.T) {
 func Test_parseEnvelope_DiskInfo_empty(t *testing.T) {
 	assert := require.New(t)
 	e := &ovf.Envelope{}
-	_, _, _, dis := parseEnvelope(e, "", "foo")
+	_, _, _, dis, got := parseEnvelope(e, "", "foo")
 	assert.Len(dis, 0, "expected no disk info")
+	assert.Equal(source.OsUnknown, got, "expected guest OS to be unknown when there is no VirtualSystem")
 }
 
 func Test_parseEnvelope_DiskInfo_ovf_v1(t *testing.T) {
 	assert := require.New(t)
 	e, err := importer.ReadEnvelope([]byte(ovfData2))
 	assert.NoError(err, "expected no error during reading envelope")
-	_, _, _, dis := parseEnvelope(e, "", "buz")
+	_, _, _, dis, got := parseEnvelope(e, "", "buz")
 	assert.Len(dis, 1, "expected one disk info")
 	assert.Equal("gm-ubuntu-test-1.vmdk", dis[0].Name, "expected name to match")
 	assert.Equal(int64(42949672960), dis[0].DiskSize, "expected size to match")
 	assert.Equal(kubevirtv1.DiskBusSCSI, dis[0].BusType, "expected bus type to match")
+	assert.Equal(source.OsUbuntu, got, "expected guest OS to be detected from the vmw:osType attribute")
 }
 
 func Test_parseEnvelope_DiskInfo_ovf_v2(t *testing.T) {
 	assert := require.New(t)
 	e, err := importer.ReadEnvelope([]byte(ovfData3))
 	assert.NoError(err, "expected no error during reading envelope")
-	_, _, _, dis := parseEnvelope(e, "", "buz")
+	_, _, _, dis, got := parseEnvelope(e, "", "buz")
 	assert.Len(dis, 1, "expected one disk info")
 	assert.Equal("ubuntu.2.0-disk1.vmdk", dis[0].Name, "expected name to match")
 	assert.Equal(int64(8589934592), dis[0].DiskSize, "expected size to match")
 	assert.Equal(kubevirtv1.DiskBusSATA, dis[0].BusType, "expected bus type to match")
+	assert.Equal(source.OsUbuntu, got, "expected guest OS to be detected from the Description fallback (no vmw:osType in this VirtualBox-exported OVF)")
 }
 
 func Test_parseEnvelope_Firmware(t *testing.T) {
@@ -602,11 +739,19 @@ func Test_parseEnvelope_Firmware(t *testing.T) {
 	for _, tc := range testCases {
 		e, err := importer.ReadEnvelope(tc.envelope)
 		assert.NoError(err, "expected no error during reading envelope")
-		fw, _, _, _ := parseEnvelope(e, "foo", "buz")
+		fw, _, _, _, _ := parseEnvelope(e, "foo", "buz")
 		assert.Equal(tc.expected.UEFI, fw.UEFI, "expected UEFI flag to match")
 		assert.Equal(tc.expected.TPM, fw.TPM, "expected TPM flag to match")
 		assert.Equal(tc.expected.SecureBoot, fw.SecureBoot, "expected SecureBoot flag to match")
 	}
+}
+
+func Test_parseEnvelope_GuestOs(t *testing.T) {
+	assert := require.New(t)
+	e, err := importer.ReadEnvelope([]byte(ovfData4))
+	assert.NoError(err, "expected no error during reading envelope")
+	_, _, _, _, got := parseEnvelope(e, "", "xyz")
+	assert.Equal(source.OsWindows, got, "expected guest OS to be detected from the ProductSection fallback (osType is absent and the Description 'Other_64' is not recognized)")
 }
 
 func Test_parseEnvelope_Hardware(t *testing.T) {
@@ -639,7 +784,7 @@ func Test_parseEnvelope_Hardware(t *testing.T) {
 	for _, tc := range testCases {
 		e, err := importer.ReadEnvelope(tc.envelope)
 		assert.NoError(err, "expected no error during reading envelope")
-		_, hw, _, _ := parseEnvelope(e, "bar", "buz")
+		_, hw, _, _, _ := parseEnvelope(e, "bar", "buz")
 		assert.Equal(tc.expected.NumCPU, hw.NumCPU, "expected CPU count to match")
 		assert.Equal(tc.expected.NumCoresPerSocket, hw.NumCoresPerSocket, "expected number of cores per socket to match")
 		assert.Equal(tc.expected.MemoryMB, hw.MemoryMB, "expected memory size to match")
@@ -650,11 +795,105 @@ func Test_parseEnvelope_NetworkInfos_v1(t *testing.T) {
 	assert := require.New(t)
 	e, err := importer.ReadEnvelope([]byte(ovfData2))
 	assert.NoError(err, "expected no error during reading envelope")
-	_, _, ni, _ := parseEnvelope(e, "baz", "buz")
+	_, _, ni, _, _ := parseEnvelope(e, "baz", "buz")
 	assert.Len(ni, 1)
 	assert.Equal("DSwitch-vCenter-HA-VM-Network", ni[0].NetworkName, "expected network name to match")
 	assert.Empty(ni[0].MAC, "expected MAC address to be empty")
 	assert.Equal(migration.NetworkInterfaceModelRtl8139, ni[0].Model, "expected network model to match")
+}
+
+func Test_detectGuestOsType(t *testing.T) {
+	tests := []struct {
+		name          string
+		virtualSystem *ovf.VirtualSystem
+		expected      string
+	}{
+		{
+			name:          "nil virtual system",
+			virtualSystem: nil,
+			expected:      source.OsUnknown,
+		},
+		{
+			name:          "empty virtual system",
+			virtualSystem: &ovf.VirtualSystem{},
+			expected:      source.OsUnknown,
+		},
+		{
+			name: "osType from a VMware-exported OVA",
+			virtualSystem: &ovf.VirtualSystem{
+				OperatingSystem: &ovf.OperatingSystemSection{
+					OSType:      ptr.To(string(types.VirtualMachineGuestOsIdentifierUbuntu64Guest)),
+					Description: ptr.To("Ubuntu Linux (64-bit)"),
+				},
+			},
+			expected: source.OsUbuntu,
+		},
+		{
+			name: "windows osType",
+			virtualSystem: &ovf.VirtualSystem{
+				OperatingSystem: &ovf.OperatingSystemSection{
+					OSType: ptr.To(string(types.VirtualMachineGuestOsIdentifierWindows2019srvNext_64Guest)),
+				},
+			},
+			expected: source.OsWindows,
+		},
+		{
+			name: "description fallback when osType is absent, e.g. a VirtualBox-exported OVA",
+			virtualSystem: &ovf.VirtualSystem{
+				OperatingSystem: &ovf.OperatingSystemSection{
+					Description: ptr.To("Ubuntu_64"),
+				},
+			},
+			expected: source.OsUbuntu,
+		},
+		{
+			name: "unrecognised osType falls back to the description",
+			virtualSystem: &ovf.VirtualSystem{
+				OperatingSystem: &ovf.OperatingSystemSection{
+					OSType:      ptr.To(string(types.VirtualMachineGuestOsIdentifierOtherGuest)),
+					Description: ptr.To("Gentoo"),
+				},
+			},
+			expected: source.OsGentoo,
+		},
+		{
+			name: "unknown osType and description fall back to the product name",
+			virtualSystem: &ovf.VirtualSystem{
+				OperatingSystem: &ovf.OperatingSystemSection{
+					OSType:      ptr.To(string(types.VirtualMachineGuestOsIdentifierOtherGuest)),
+					Description: ptr.To("Other (32-bit)"),
+				},
+				Product: []ovf.ProductSection{{Product: "Windows"}},
+			},
+			expected: source.OsWindows,
+		},
+		{
+			name: "operating system section absent entirely, product name is the only source",
+			virtualSystem: &ovf.VirtualSystem{
+				Product: []ovf.ProductSection{{Product: "Windows"}},
+			},
+			expected: source.OsWindows,
+		},
+		{
+			name: "unknown osType, description and product name",
+			virtualSystem: &ovf.VirtualSystem{
+				OperatingSystem: &ovf.OperatingSystemSection{
+					OSType:      ptr.To(string(types.VirtualMachineGuestOsIdentifierOtherGuest)),
+					Description: ptr.To("Other (32-bit)"),
+				},
+				Product: []ovf.ProductSection{{Product: "My Custom App"}},
+			},
+			expected: source.OsUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectGuestOsType(tt.virtualSystem); got != tt.expected {
+				t.Fatalf("expected %q got %q", tt.expected, got)
+			}
+		})
+	}
 }
 
 func Test_downloadArchive(t *testing.T) {

--- a/pkg/source/vmware/client.go
+++ b/pkg/source/vmware/client.go
@@ -222,15 +222,20 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) (err e
 		"name":      vm.Name,
 		"namespace": vm.Namespace,
 		"spec":      info.Items,
-	}, []string{"spec"})).Info("Origin spec of the volumes to be imported")
+	}, []string{"spec"})).Info("The volumes to be imported")
 
-	var vmMo mo.VirtualMachine
-	err = vmObj.Properties(c.ctx, vmObj.Reference(),
-		[]string{"config.hardware.device"},
-		&vmMo)
+	var o mo.VirtualMachine
+	err = vmObj.Properties(c.ctx, vmObj.Reference(), []string{}, &o)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve VM hardware devices: %w", err)
+		return fmt.Errorf("error retrieving VM properties: %w", err)
 	}
+
+	// Log the origin VM specification for better troubleshooting.
+	logrus.WithFields(util.FieldsToJSON(logrus.Fields{
+		"name":      vm.Name,
+		"namespace": vm.Namespace,
+		"spec":      o,
+	}, []string{"spec"})).Info("Origin spec of the VM to be imported")
 
 	diskByBusUnit := map[diskKey]*types.VirtualDisk{}
 	controllerBus := map[int32]int32{}
@@ -238,7 +243,7 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) (err e
 	// by building this map, we can later match each lease disk entry to the corresponding
 	// VirtualDisk device in the VM hardware and retrieve the correct disk
 	// capacity from the VM configuration instead of relying on the incorrect LeaseInfo.Items[n].Size value.
-	for _, dev := range vmMo.Config.Hardware.Device {
+	for _, dev := range o.Config.Hardware.Device {
 		if d, ok := dev.(types.BaseVirtualController); ok {
 			ctrl := d.GetVirtualController()
 			controllerBus[dev.GetVirtualDevice().Key] = ctrl.BusNumber
@@ -247,7 +252,7 @@ func (c *Client) ExportVirtualMachine(vm *migration.VirtualMachineImport) (err e
 
 	// it's rare, but we cannot ensure the controller will always be before the disk in the list of devices
 	// so we need to loop through the devices twice to build a map of disks by their bus and unit numbers
-	for _, dev := range vmMo.Config.Hardware.Device {
+	for _, dev := range o.Config.Hardware.Device {
 		if d, ok := dev.(*types.VirtualDisk); ok {
 			if d.UnitNumber == nil {
 				continue
@@ -440,19 +445,10 @@ func (c *Client) GenerateVirtualMachine(vm *migration.VirtualMachineImport) (*ku
 	}
 
 	var o mo.VirtualMachine
-
 	err = vmObj.Properties(c.ctx, vmObj.Reference(), []string{}, &o)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error retrieving VM properties: %w", err)
 	}
-
-	// Log the origin VM specification for better troubleshooting.
-	// Note, JSON is used to be able to prettify the output for better readability.
-	logrus.WithFields(util.FieldsToJSON(logrus.Fields{
-		"name":      vm.Name,
-		"namespace": vm.Namespace,
-		"spec":      o,
-	}, []string{"spec"})).Info("Origin spec of the VM to be imported")
 
 	// Need CPU, Socket, Memory, VirtualNIC information to perform the mapping
 	networkInfos := generateNetworkInfos(c.networkMapping, o.Config.Hardware.Device)
@@ -476,6 +472,9 @@ func (c *Client) GenerateVirtualMachine(vm *migration.VirtualMachineImport) (*ku
 	vmSpec.Template.Spec.Networks = networkConfig
 	vmSpec.Template.Spec.Domain.Devices.Interfaces = interfaceConfig
 	newVM.Spec = *vmSpec
+
+	guestOsType := detectGuestOsType(&o)
+	source.ApplyGuestOsLabel(newVM, guestOsType)
 
 	// disk attachment needs query by core controller for storage classes, so will be added by the migration controller
 	return newVM, nil
@@ -764,7 +763,7 @@ type diskKey struct {
 //
 //	/vm-13010/VirtualSCSIController0:0  -> bus=0, unit=0
 //	/vm-13010/VirtualNVMEController1:2  -> bus=1, unit=2
-//	scsi0:1                            -> bus=0, unit=1
+//	scsi0:1                             -> bus=0, unit=1
 //
 // The controller prefix may vary (SCSI, NVME, AHCI, IDE, etc.).
 // Only the trailing digits before ":" represent the bus number.
@@ -802,4 +801,86 @@ func parseDeviceId(deviceId string) (bus int32, unit int32, ok bool) {
 	}
 
 	return int32(bus64), int32(unit64), true
+}
+
+// detectGuestOsType determines the guest OS type of a VMware virtual
+// machine, preferring the most specific and reliable source available:
+//  1. GuestId (Config/Guest/Summary): the guest OS identifier chosen when
+//     the VM was created. Always available and, being a fixed VMware enum,
+//     can be classified precisely, down to distribution level.
+//  2. GuestFullName/AlternateGuestName: free text, used as a fallback for
+//     "otherGuest"/custom guest IDs and for distributions VMware has no
+//     dedicated identifier for (e.g. Gentoo).
+//  3. Guest.GuestFamily: the coarse family (windows/linux, no distribution)
+//     reported by VMware Tools. vCenter retains the last reported value
+//     even after the VM is powered off, so it's still a useful last resort.
+func detectGuestOsType(o *mo.VirtualMachine) string {
+	if o == nil {
+		return source.OsUnknown
+	}
+
+	for _, id := range guestOsIds(o) {
+		if osType := source.GuestOsIdToOsType(id); osType != source.OsUnknown {
+			return osType
+		}
+	}
+
+	for _, name := range guestOsNames(o) {
+		if osType := source.GuestOsNameToOsType(name); osType != source.OsUnknown {
+			return osType
+		}
+	}
+
+	if o.Guest != nil {
+		if osType := guestOsFamilyToOsType(o.Guest.GuestFamily); osType != source.OsUnknown {
+			return osType
+		}
+	}
+
+	return source.OsUnknown
+}
+
+// guestOsFamilyToOsType classifies the coarse guest OS family reported by
+// VMware Tools. Unlike a guest OS identifier or name, this has no
+// distribution-level detail, so it's VMware/vSphere-specific and not shared
+// with the OVA importer.
+func guestOsFamilyToOsType(family string) string {
+	switch types.VirtualMachineGuestOsFamily(family) {
+	case types.VirtualMachineGuestOsFamilyWindowsGuest:
+		return source.OsWindows
+	case types.VirtualMachineGuestOsFamilyLinuxGuest:
+		return source.OsLinux
+	default:
+		return source.OsUnknown
+	}
+}
+
+func guestOsIds(o *mo.VirtualMachine) []string {
+	ids := make([]string, 0, 4)
+	if o.Config != nil {
+		ids = append(ids, o.Config.GuestId)
+	}
+	if o.Guest != nil {
+		ids = append(ids, o.Guest.GuestId)
+	}
+	if o.Summary.Guest != nil {
+		ids = append(ids, o.Summary.Guest.GuestId)
+	}
+	ids = append(ids, o.Summary.Config.GuestId)
+	return ids
+}
+
+func guestOsNames(o *mo.VirtualMachine) []string {
+	names := make([]string, 0, 4)
+	if o.Config != nil {
+		names = append(names, o.Config.GuestFullName, o.Config.AlternateGuestName)
+	}
+	if o.Guest != nil {
+		names = append(names, o.Guest.GuestFullName)
+	}
+	if o.Summary.Guest != nil {
+		names = append(names, o.Summary.Guest.GuestFullName)
+	}
+	names = append(names, o.Summary.Config.GuestFullName)
+	return names
 }

--- a/pkg/source/vmware/client_test.go
+++ b/pkg/source/vmware/client_test.go
@@ -23,6 +23,10 @@ import (
 	"github.com/harvester/vm-import-controller/pkg/source"
 )
 
+const (
+	vcsimContainerName = "vcsim"
+)
+
 var vcsimPort string
 
 // setup mock vmware endpoint
@@ -32,9 +36,14 @@ func TestMain(t *testing.M) {
 		log.Fatalf("error connecting to dockerd: %v", err)
 	}
 
+	// Remove a leftover container from a previous, interrupted test run.
+	if err := pool.RemoveContainerByName(vcsimContainerName); err != nil {
+		log.Fatalf("error removing leftover %q container: %v", vcsimContainerName, err)
+	}
+
 	// https://hub.docker.com/r/vmware/vcsim
 	runOpts := &dockertest.RunOptions{
-		Name:       "vcsim",
+		Name:       vcsimContainerName,
 		Repository: "vmware/vcsim",
 		Tag:        "v0.49.0",
 	}
@@ -42,7 +51,7 @@ func TestMain(t *testing.M) {
 	vcsimMock, err := pool.RunWithOptions(runOpts)
 
 	if err != nil {
-		log.Fatalf("error creating vcsim container: %v", err)
+		log.Fatalf("error creating %q container: %v", vcsimContainerName, err)
 	}
 
 	vcsimPort = vcsimMock.GetPort("8989/tcp")
@@ -55,7 +64,7 @@ func TestMain(t *testing.M) {
 
 	code := t.Run()
 	if err := pool.Purge(vcsimMock); err != nil {
-		log.Fatalf("error purging vcsimMock container: %v", err)
+		log.Fatalf("error purging %q container: %v", vcsimContainerName, err)
 	}
 
 	os.Exit(code)
@@ -597,6 +606,166 @@ func TestParseDeviceId(t *testing.T) {
 				if unit != tt.unit {
 					t.Fatalf("expected unit=%d got %d", tt.unit, unit)
 				}
+			}
+		})
+	}
+}
+
+func TestDetectGuestOsType(t *testing.T) {
+	tests := []struct {
+		name     string
+		vm       *mo.VirtualMachine
+		expected string
+	}{
+		{
+			name: "windows from config guest id",
+			vm: &mo.VirtualMachine{
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierWindows9Server64Guest)},
+			},
+			expected: source.OsWindows,
+		},
+		{
+			name: "windows server 2019 from config guest id",
+			vm: &mo.VirtualMachine{
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierWindows2019srvNext_64Guest)},
+			},
+			expected: source.OsWindows,
+		},
+		{
+			name: "windows server 2003 guest id does not contain the word windows",
+			vm: &mo.VirtualMachine{
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierWinNetStandardGuest)},
+			},
+			expected: source.OsWindows,
+		},
+		{
+			name: "legacy windows xp guest id",
+			vm: &mo.VirtualMachine{
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierWinXPProGuest)},
+			},
+			expected: source.OsWindows,
+		},
+		{
+			name: "linux from guest family",
+			vm: &mo.VirtualMachine{
+				Guest: &types.GuestInfo{GuestFamily: "linuxGuest"},
+			},
+			expected: source.OsLinux,
+		},
+		{
+			name: "windows from guest family even with a non-matching guest id",
+			vm: &mo.VirtualMachine{
+				Guest:  &types.GuestInfo{GuestFamily: "windowsGuest"},
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierOtherGuest)},
+			},
+			expected: source.OsWindows,
+		},
+		{
+			name: "sles guest id",
+			vm: &mo.VirtualMachine{
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierSles15_64Guest)},
+			},
+			expected: source.OsSLES,
+		},
+		{
+			name: "opensuse guest id is not detected as sles",
+			vm: &mo.VirtualMachine{
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierOpensuse64Guest)},
+			},
+			expected: source.OsOpenSUSE,
+		},
+		{
+			name: "ubuntu guest id",
+			vm: &mo.VirtualMachine{
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierUbuntu64Guest)},
+			},
+			expected: source.OsUbuntu,
+		},
+		{
+			name: "rhel guest id maps to the redhat entry",
+			vm: &mo.VirtualMachine{
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierRhel9_64Guest)},
+			},
+			expected: source.OsRedHat,
+		},
+		{
+			name: "centos guest id maps to the harvester otherLinux entry",
+			vm: &mo.VirtualMachine{
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierCentos7_64Guest)},
+			},
+			expected: source.OsOtherLinux,
+		},
+		{
+			name: "generic linux guest id family",
+			vm: &mo.VirtualMachine{
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierOther5xLinux64Guest)},
+			},
+			expected: source.OsLinux,
+		},
+		{
+			name: "gentoo has no vmware guest id and is only detected via free text",
+			vm: &mo.VirtualMachine{
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierOtherLinuxGuest), GuestFullName: "Gentoo"},
+			},
+			expected: source.OsLinux,
+		},
+		{
+			name: "darwin guest id is not misdetected as windows",
+			vm: &mo.VirtualMachine{
+				Config: &types.VirtualMachineConfigInfo{GuestId: string(types.VirtualMachineGuestOsIdentifierDarwin19_64Guest)},
+			},
+			expected: source.OsUnknown,
+		},
+		{
+			name: "linux from summary guest full name",
+			vm: &mo.VirtualMachine{
+				Summary: types.VirtualMachineSummary{
+					Guest: &types.VirtualMachineGuestSummary{GuestFullName: "Ubuntu Linux (64-bit)"},
+				},
+			},
+			expected: source.OsUbuntu,
+		},
+		{
+			name: "windows from summary guest full name",
+			vm: &mo.VirtualMachine{
+				Summary: types.VirtualMachineSummary{
+					Guest: &types.VirtualMachineGuestSummary{GuestFullName: "Microsoft Windows Server 2022 (64-bit)"},
+				},
+			},
+			expected: source.OsWindows,
+		},
+		{
+			name:     "unknown when no hint",
+			vm:       &mo.VirtualMachine{},
+			expected: source.OsUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectGuestOsType(tt.vm); got != tt.expected {
+				t.Fatalf("expected %q got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestGuestOsFamilyToOsType(t *testing.T) {
+	tests := []struct {
+		name     string
+		family   string
+		expected string
+	}{
+		{name: "windows", family: string(types.VirtualMachineGuestOsFamilyWindowsGuest), expected: source.OsWindows},
+		{name: "linux", family: string(types.VirtualMachineGuestOsFamilyLinuxGuest), expected: source.OsLinux},
+		{name: "solaris is not windows or linux", family: string(types.VirtualMachineGuestOsFamilySolarisGuest), expected: source.OsUnknown},
+		{name: "empty", family: "", expected: source.OsUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := guestOsFamilyToOsType(tt.family); got != tt.expected {
+				t.Fatalf("expected %q got %q", tt.expected, got)
 			}
 		})
 	}

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -134,6 +134,11 @@ var _ = BeforeSuite(func() {
 
 	pool, err = dockertest.NewPool("")
 	Expect(err).NotTo(HaveOccurred())
+
+	// Remove a leftover container from a previous, interrupted test run.
+	err = pool.RemoveContainerByName("vcsim-integration")
+	Expect(err).NotTo(HaveOccurred())
+
 	runOpts := &dockertest.RunOptions{
 		Name:       "vcsim-integration",
 		Repository: "vmware/vcsim",


### PR DESCRIPTION
**Problem:**
The vm-import-controller currently imports hardware related configuration from the source VM, (CPU,Mem,firmware,disks,network,etc...), but it does not preserve guest operating system metadata.

As a result, The imported VirtualMachine contains no metadata indicating the original guest operating system and defaulted to `linux` from UI form.

**Solution:**
- Extract the OS type from the VM specifications and set the label “harvesterhci.io/os”.
- Log the VM specification as early as possible. Since this is not done until a later stage in the current implementation, this useful information is unfortunately not available if problems occur before then. This is now being addressed by logging the specification at the earliest possible time.
- Remove a leftover container from a previous, interrupted test run.
- Overall code cleanup.

**Related Issue:**
Related to: https://github.com/harvester/harvester/issues/11072

**Test plan:**
- Import a Windows based VM via VMware, OpenStack or OVA.
You can use the following `VirtualMachineImport` to import a VM from our test system.
```
apiVersion: migration.harvesterhci.io/v1beta1
kind: VirtualMachineImport
metadata:
  name: haffel-ci-test
  namespace: default
spec: 
  virtualMachineName: "haffel-ci-test"
  folder: "haffel"
  networkMapping:
  - sourceNetwork: "VM-Network"
    destinationNetwork: "default/vlan1"
  sourceCluster: 
    name: vcsim
    namespace: default
    kind: VmwareSource
    apiVersion: migration.harvesterhci.io/v1beta1
```
Note, the VM is very big and might cause timeouts when using VPN.
- Check in Harvester under `Virtual Machines` that the `OS Type` dropdown on the `Advanced Options` tab is showing `Windows`.
<img width="1056" height="628" alt="grafik" src="https://github.com/user-attachments/assets/dfee2e68-8661-40e6-b757-7b05d3f060b3" />
- Alternatively check the YAML code of the VM CR for the `harvesterhci.io/os` label:

```
id: default/haffel-ci-test
type: kubevirt.io.virtualmachine
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  annotations:
    harvesterhci.io/vmRunStrategy: RerunOnFailure
    kubevirt.io/latest-observed-api-version: v1
    kubevirt.io/storage-observed-api-version: v1
...
  labels:
    harvesterhci.io/os: windows
...
```
