### PR TITLE
Publish images via harvester-actions registry actions

### DIFF
--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -11,7 +11,8 @@ on:
         required: true
         type: boolean
 env:
-  imageName: "rancher/harvester-vm-import-controller"
+  PLATFORMS: linux/amd64,linux/arm64
+  imageName: harvester-vm-import-controller
 
 jobs:
   ci-build:
@@ -39,27 +40,78 @@ jobs:
       - name: Run CI
         run: make ci
 
-      - name: Read some Secrets
-        uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
-        if: ${{ inputs.push == true }}
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
-        if: ${{ inputs.push == true }}
-        with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
-
       - name: Docker Build
+        if: ${{ inputs.push == false }}
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           provenance: false
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           file: package/Dockerfile
-          push: ${{ inputs.push }}
-          tags: ${{env.imageName}}:${{ inputs.release-tag-name }}
+          push: false
+          tags: ${{ env.imageName }}:${{ inputs.release-tag-name }}
+
+      - name: Resolve registries
+        id: resolve
+        if: ${{ inputs.push == true }}
+        uses: harvester/harvester-actions/actions/resolve-registries@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+        with:
+          release-tag-name: ${{ inputs.release-tag-name }}
+          is-release: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+
+      - name: Set image tag
+        if: ${{ inputs.push == true }}
+        run: echo "IMAGE_TAG=${RELEASE_TAG_NAME#prime-}" >> "$GITHUB_ENV"
+        env:
+          RELEASE_TAG_NAME: ${{ inputs.release-tag-name }}
+
+      - name: Login to Docker Hub
+        id: login-docker
+        if: ${{ inputs.push == true && steps.resolve.outputs.use-docker-io == 'true' }}
+        uses: harvester/harvester-actions/actions/login-docker-hub@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+
+      - name: Publish public ${{ env.imageName }} image
+        if: ${{ inputs.push == true && steps.resolve.outputs.use-docker-io == 'true' }}
+        uses: harvester/harvester-actions/actions/publish-public-image@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+        with:
+          context: .
+          dockerfile: package/Dockerfile
+          image: ${{ env.imageName }}
+          tag: ${{ env.IMAGE_TAG }}
+          platforms: ${{ env.PLATFORMS }}
+          registry: ${{ steps.login-docker.outputs.registry }}
+          repository: ${{ steps.login-docker.outputs.repository }}
+
+      - name: Login to Staging Registry
+        id: login-staging
+        if: ${{ inputs.push == true && steps.resolve.outputs.use-staging == 'true' }}
+        uses: harvester/harvester-actions/actions/login-staging-registry@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+
+      - name: Publish staging ${{ env.imageName }} image
+        if: ${{ inputs.push == true && steps.resolve.outputs.use-staging == 'true' }}
+        uses: harvester/harvester-actions/actions/publish-prime-image@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+        with:
+          context: .
+          dockerfile: package/Dockerfile
+          image: ${{ env.imageName }}
+          tag: ${{ env.IMAGE_TAG }}
+          platforms: ${{ env.PLATFORMS }}
+          registry: ${{ steps.login-staging.outputs.registry }}
+          repository: ${{ steps.login-staging.outputs.repository }}
+
+      - name: Login to Prime Registry
+        id: login-prime
+        if: ${{ inputs.push == true && steps.resolve.outputs.use-prime == 'true' }}
+        uses: harvester/harvester-actions/actions/login-prime-registry@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+
+      - name: Publish prime ${{ env.imageName }} image
+        if: ${{ inputs.push == true && steps.resolve.outputs.use-prime == 'true' }}
+        uses: harvester/harvester-actions/actions/publish-prime-image@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+        with:
+          context: .
+          dockerfile: package/Dockerfile
+          image: ${{ env.imageName }}
+          tag: ${{ env.IMAGE_TAG }}
+          platforms: ${{ env.PLATFORMS }}
+          registry: ${{ steps.login-prime.outputs.registry }}
+          repository: ${{ steps.login-prime.outputs.repository }}


### PR DESCRIPTION
- Use the shared harvester/harvester-actions actions so images are conditionally published to docker.io, the staging registry, and the prime registry.
  - Branch merge: push to the public and staging registries.
  - Tag (v*): push to the public registry.
  - Tag (`prime-*`): push to the prime registry.
- Keep a push:false docker/build-push-action step as a build-only sanity check on non-push (e.g. PR) runs, since the shared publish actions always push.

note: need to refer to https://github.com/harvester/harvester-actions for actions

